### PR TITLE
Add Error History functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ ifneq ($(CROSS_COMPILE),)
 	LDFLAGS += -static
 endif
 
-#CXXFLAGS = -DDEBUG -DDEBUG_BSG_DATA
+#CXXFLAGS = -DDEBUG
 
 objects = \
 	ufs.o \
 	ufs_cmds.o \
 	options.o \
 	scsi_bsg_util.o \
+	ufs_err_hist.o
 
 CHECKFLAGS = -Wall  -Wundef
 

--- a/README
+++ b/README
@@ -1,10 +1,14 @@
-UFS Tool ver 1.0
+UFS Tool ver 1.1
 
 1) Description:
-	The tool uses the BSG infrastructure in linux kernel (applied to 5.1 rc1) in order to read/write device flags,
-	attributes & descriptors.
-	Due to the issue in UFS BSG driver, the following patch have to be applied:
-	https://lore.kernel.org/patchwork/patch/1076796/
+	The tool include the following features:
+	a) Read/Write device flags, attributes & descriptors by
+	   using the BSG infrastructure in linux kernel (applied to 5.1 rc1)
+	   Due to the issues in UFS BSG driver, the following patch have to be
+	   applied:
+	   https://lore.kernel.org/patchwork/patch/1076796/
+	   https://patchwork.kernel.org/patch/11011891/
+	b) Error History
 	The tool is aligned to the UFS 3.0 spec.
 
 2) Build
@@ -26,7 +30,7 @@ UFS Tool ver 1.0
         ufs-tool -v
                 Show the version.
 
-        ufs-tool <desc | attr | fl> --help|-h
+        ufs-tool <desc | attr | fl | err_hist> --help|-h
                 Show detailed help for a command
 
 	Run the tool's help for the ufs configuration features in order to get full information

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
-# UFS Tool ver 1.0 #
+# UFS Tool ver 1.1 #
 
 ## Description: ##
-The tool uses the BSG infrastructure in linux kernel
-(applied to 5.1 rc1) in order to read/write device flags,
-attributes & descriptors.
-Due to the issue in UFS BSG driver, the following patch
-have to be applied:
-https://lore.kernel.org/patchwork/patch/1076796/
-The tool is aligned to the UFS 3.0 spec.
+a) Read/Write device flags, attributes & descriptors by
+using the BSG infrastructure in linux kernel (applied to 5.1 rc1)   
+Due to the issues in UFS BSG driver, the following patch have to be
+applied:   
+   https://lore.kernel.org/patchwork/patch/1076796/   
+   https://patchwork.kernel.org/patch/11011891/   
+b) Error History   
+The tool is aligned to the UFS 3.0 spec.   
 
 ## Build: ##
 ### Set CROSS\_COMPILE variable(e.g.): ###
-export CROSS\_COMPILE=/XXX/aarch64-linux-gnu- 
-### Build:### 
-"make" 
-### Clean:###
- "make clean"  
+export CROSS\_COMPILE=/XXX/aarch64-linux-gnu-
+
+### Build: ###
+"make"
+
+### Clean: ###
+ "make clean"   
 
 ## Usage ##
 Copy the tool into a directory on the device (e.g.
@@ -23,19 +26,19 @@ Copy the tool into a directory on the device (e.g.
 Run the tool without arguments or with -h/--help
     options in order to list the supported features:   
 E.g. Run:  
-./ufs\-tool --help  
+./ufs-tool --help  
 Output:
-    ufs\-tool help|--help|-h Show the help.
+    ufs-tool help|--help|-h Show the help.
 
         ufs-tool -v
                 Show the version.
 
-        ufs-tool <desc | attr | fl> --help|-h
+        ufs-tool <desc | attr | fl | err_hist> --help|-h
                 Show detailed help for a command
 
     Run the tool's help for the ufs configuration features in order to
     get full information related to the feature, all options and the
-    examples. E.g.: getting help for ufs flags Run: ./ufs\-tool fl --help
+    examples. E.g.: getting help for ufs flags Run: ./ufs-tool fl --help
     Output: Flags command usage:
 
         ufs-tool fl [-t] <flag idn> [-a|-r|-o|-e] [-p] <device_path> 

--- a/options.c
+++ b/options.c
@@ -193,8 +193,9 @@ static int verify_arg_and_set_default(struct tool_options *options)
 		print_error("Data missed for the write operation");
 		goto out;
 	}
-
-	if (options->opr != READ_ALL && options->idn == INVALID) {
+	if (options->config_type_inx != ERR_HIST_TYPE &&
+			options->opr != READ_ALL &&
+			options->idn == INVALID) {
 		print_error("The type idn is missed");
 		goto out;
 	}

--- a/scsi_bsg_util.h
+++ b/scsi_bsg_util.h
@@ -11,9 +11,20 @@
  */
 
 #define UFS_CDB_SIZE	16
-#define UPIU_TRANSACTION_UIC_CMD 0x1F
-/* uic commands are 4DW long, per UFSHCI V2.1 paragraph 5.6.1 */
-#define UIC_CMD_SIZE (sizeof(__u32) * 4)
+
+#define BUFFER_DATA_MODE 0x02
+#define BUFFER_FFU_MODE 0x0E
+#define BUFFER_EHS_MODE 0x1C
+
+#define SG_DXFER_NONE -1        /* e.g. a SCSI Test Unit Ready command */
+#define SG_DXFER_TO_DEV -2      /* e.g. a SCSI WRITE command */
+#define SG_DXFER_FROM_DEV -3    /* e.g. a SCSI READ command */
+
+#define SENSE_BUFF_LEN	(32)
+#define WRITE_BUF_CMDLEN 10
+#define READ_BUF_CMDLEN 10
+#define WRITE_BUFFER_CMD 0x3B
+#define READ_BUFFER_CMD 0x3c
 
 /**
  * struct utp_upiu_header - UPIU header structure
@@ -106,10 +117,12 @@ struct ufs_bsg_reply {
 #define BSG_REPLY_SZ (sizeof(struct ufs_bsg_reply))
 #define BSG_REQUEST_SZ (sizeof(struct ufs_bsg_request))
 
-int send_bsg_sg_io(int fd, struct ufs_bsg_request *request_buff,
+int send_bsg_scsi_trs(int fd, struct ufs_bsg_request *request_buff,
 		struct ufs_bsg_reply *reply_buff, __u32 request_len,
 		__u32 reply_len, __u8 *data_buf);
 void prepare_upiu(struct ufs_bsg_request *bsg_req, __u8 query_req_func,
-		  __u16 data_len, __u8 opcode, __u8 idn, __u8 index, __u8 sel);
+		__u16 data_len, __u8 opcode, __u8 idn, __u8 index, __u8 sel);
+int read_buffer(int fd, __u8 *buf, uint8_t mode, __u8 buf_id,
+		__u32 buf_offset, int byte_count);
 #endif /* BSG_UTIL_H_ */
 

--- a/ufs.c
+++ b/ufs.c
@@ -13,8 +13,9 @@
 #include "ufs_cmds.h"
 #include "options.h"
 #include "ufs.h"
+#include "ufs_err_hist.h"
 
-#define UFS_BSG_UTIL_VERSION	"1.0"
+#define UFS_BSG_UTIL_VERSION	"1.1"
 typedef int (*command_function)(struct tool_options *opt);
 
 struct tool_command {
@@ -30,6 +31,7 @@ static struct tool_command commands[] = {
 	{ do_desc, "desc", DESC_TYPE},
 	{ do_attributes, "attr", ATTR_TYPE},
 	{ do_flags, "fl", FLAG_TYPE},
+	{ do_err_hist, "err_hist", ERR_HIST_TYPE},
 	{ 0, 0, 0}
 };
 
@@ -50,8 +52,7 @@ static void help(char *np)
 {
 	char help_str[256] = {0};
 
-	strcat(help_str, "<desc | attr | fl");
-	strcat(help_str, ">");
+	strcat(help_str, "<desc | attr | fl | err_hist>");
 	printf("\n Usage:\n");
 	printf("\n\t%s help|--help|-h\n\t\tShow the help.\n", np);
 	printf("\n\t%s -v\n\t\tShow the version.\n", np);
@@ -106,6 +107,29 @@ static int parse_args(int argc, char **argv, command_function *func,
 	rc = init_options(argc, argv, options);
 
 out:
+	return rc;
+}
+
+int write_file(const char *name, const void *buffer, int length)
+{
+	int fd;
+	int rc = 0;
+	size_t ret;
+
+	WRITE_LOG("writing file %s length=%d\n", name, length);
+	fd = open(name, O_RDWR | O_CREAT | O_TRUNC | O_SYNC, 0600);
+	if (fd == -1) {
+		WRITE_LOG("%s: failed in open errno=%d", __func__, errno);
+		return -ENOENT;
+	}
+
+	ret = write(fd, buffer, length);
+	if (length != ret) {
+		WRITE_LOG("%s: failed in write errno=%d", __func__, errno);
+		rc = -EIO;
+	}
+
+	close(fd);
 	return rc;
 }
 

--- a/ufs.h
+++ b/ufs.h
@@ -11,6 +11,13 @@
 #define BLOCK_SIZE 512
 #define MAX_UFS_COMMAND_LEN 16
 
+/*
+ * Generally the max HW max chunk is 512KB,
+ * but in order to be in safe side tool using 256KB as max chunk size
+ * between user and kernel space
+*/
+#define MAX_IOCTL_BUF_SIZE (256L * 1024)
+
 /* Flag idn for Query Requests*/
 enum flag_idn {
 	QUERY_FLAG_IDN_RESERVED1		= 0x00,
@@ -126,7 +133,8 @@ enum {
 enum ufs_cong_type {
 	DESC_TYPE = 0,
 	ATTR_TYPE,
-	FLAG_TYPE
+	FLAG_TYPE,
+	ERR_HIST_TYPE
 };
 
 /* UTP UPIU Transaction Codes Initiator to Target */
@@ -138,6 +146,7 @@ enum {
 	UPIU_TRANSACTION_QUERY_REQ	= 0x16,
 };
 
+int write_file(const char *name, const void *buffer, int length);
 void print_error(const char *msg, ...);
 #ifdef DEBUG
 	#define WRITE_LOG(format, ...) fprintf(stderr, format"\n", __VA_ARGS__)

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -16,6 +16,7 @@
 #include "ufs_cmds.h"
 #include "options.h"
 #include "scsi_bsg_util.h"
+#include "ufs_err_hist.h"
 
 #define STR_BUF_LEN 33
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -394,7 +395,7 @@ void print_descriptors(char *desc_str, __u8 *desc_buf,
 		} else if (tmp->width_in_bytes == DDWORD) {
 			printf("%s [Byte offset 0x%x]: %s = 0x%lx\n",
 				desc_str, tmp->offset, tmp->name,
-				be64toh(*(uint64_t *)&desc_buf[tmp->offset]));
+				be64toh(*(__u64 *)&desc_buf[tmp->offset]));
 		} else if ((tmp->width_in_bytes > DDWORD) &&
 				tmp->width_in_bytes < STR_BUF_LEN) {
 			memset(str_buf, 0, STR_BUF_LEN);
@@ -905,7 +906,7 @@ static int do_query_rq(int fd, struct ufs_bsg_request *bsg_req,
 	prepare_upiu(bsg_req, query_req_func, len, opcode, idn,
 		index, sel);
 
-	rc = send_bsg_sg_io(fd, bsg_req, bsg_rsp, req_buf_len, res_buf_len,
+	rc = send_bsg_scsi_trs(fd, bsg_req, bsg_rsp, req_buf_len, res_buf_len,
 			data_buf);
 
 	if (rc) {
@@ -1172,6 +1173,9 @@ void print_command_help(char *prgname, int config_type)
 	case FLAG_TYPE:
 		flag_help(prgname);
 		break;
+	case ERR_HIST_TYPE:
+		err_hist_help(prgname);
+	break;
 	default:
 		print_error("Unsupported cmd type");
 		break;

--- a/ufs_err_hist.c
+++ b/ufs_err_hist.c
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (C) 2019 Western Digital Corporation or its affiliates */
+
+/*
+ * UFS3.0(UFSv3.0 JESD220D spec.) allows to retrieve the error history by using
+ * the READ BUFFER command.
+ */
+
+#include "ufs_err_hist.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "ufs.h"
+#include "ufs_cmds.h"
+#include "options.h"
+#include "ioctl.h"
+
+#define MIN(a, b) (((a) < (b))?(a):(b))
+#define MAX(a, b) (((a) > (b))?(a):(b))
+
+/*
+ * The spec actualy says: "and ALLOCATION LENGTH set to at least 2088
+ * (i.e., large enough to transfer the complete error history directory)."
+ * This is apparently an error because it doesn't adds up to the entries
+ * count and sizes: The error history header is 32bytes, and there can be
+ * up to (0xEF – 0x10 + 1) = 224 entries. Each entry is 8bytes, so the
+ * directory should weight 224*8 + 32 = 1824bytes, and not 2088.
+ */
+#define EHS_DIR_ALLOC_LEN 1824
+/* According to the spec, BUF ID can be between 0x10 0xEF range */
+#define EHS_MIN_BUF_ID 0x10
+#define EHS_MAX_BUF_ID 0xEF
+#define EHS_MAX_ENTRIES (EHS_MAX_BUF_ID - EHS_MIN_BUF_ID + 1)
+/* 3 bytes for Allocation Length field + 3 bytes for Buffer offset field*/
+#define READ_BUF_MAX_AVAIL_LEN (0xFFFFFF + 0xFFFFFF)
+#define BLOCKS_IN_FAD_BLOCK (MAX_IOCTL_BUF_SIZE / BLOCK_SIZE)
+
+struct ehs_directory_entry {
+	u_int8_t buffer_id;
+	u_int8_t reserved[3];
+	u_int32_t length;
+};
+
+struct ehs_directory_header {
+	u_int8_t vendor_id[8];
+	u_int8_t version;
+	u_int8_t reserved1;
+	u_int8_t reserved2[20];
+	u_int16_t length;
+};
+
+struct ehs_directory_buffer {
+	struct ehs_directory_header hdr;
+	struct ehs_directory_entry entries[EHS_MAX_ENTRIES];
+};
+
+static inline int write_single_fad(const int file, const void *buffer, int sz)
+{
+	if (write(file, buffer, sz) !=  sz)
+		return -EIO;
+	else
+		return 0;
+}
+
+static int log_ehs_buffer(int fd, int file, __u8 *buf, __u8 buf_id,
+			  __u32 len)
+{
+	int rc = -EINVAL;
+	__u32 sent = 0;
+	int i = 0;
+
+	printf("\nPlease wait for error history extraction\n");
+	while (sent < len) {
+		__u32 ofst = i * MAX_IOCTL_BUF_SIZE;
+		__u32 sz =
+			(len - sent >= MAX_IOCTL_BUF_SIZE) ? MAX_IOCTL_BUF_SIZE :
+							(len - sent);
+
+		rc = read_buffer(fd, buf, BUFFER_EHS_MODE, buf_id, ofst, sz);
+		if (rc) {
+			print_error("read_buffer buff_id 0x%x fad %d",
+				buf_id, i);
+			goto out;
+		}
+
+		rc = write_single_fad(file, buf, sz);
+		if (rc) {
+			print_error("write buf_id 0x%x fad %d", buf_id, i);
+			goto out;
+		}
+
+		sent += sz;
+		i++;
+		memset(buf, 0x0, MAX_IOCTL_BUF_SIZE);
+	}
+
+	rc = 0;
+out:
+	return rc;
+}
+
+static int log_error_history(int fd, struct ehs_directory_entry *entries,
+			__u8 buffers_cnt)
+{
+	int file;
+	__u8 *buf = NULL;
+	int rc = -EINVAL;
+	int i;
+
+	file = open("error_history.dat", O_RDWR | O_CREAT | O_TRUNC | O_SYNC,
+		S_IWUSR | S_IRUSR);
+	if (file == -1) {
+		perror("open");
+		goto out;
+	}
+
+	/* IO size is limited by max_sectors_kb which is usually 512k - set a
+	 * slightly smaller chunk - 256k.
+	 */
+	buf = calloc(1, MAX_IOCTL_BUF_SIZE);
+	if (!buf) {
+		rc = -ENOMEM;
+		goto out;
+	}
+
+	for (i = 0; i < buffers_cnt; i++) {
+		struct ehs_directory_entry *entry = entries + i;
+		u_int8_t buf_id = entry->buffer_id;
+		u_int32_t len = be32toh(entry->length);
+
+		if (buf_id < EHS_MIN_BUF_ID || buf_id > EHS_MAX_BUF_ID) {
+			print_error("illegal buffer id 0x%x entry %d",
+				buf_id, i);
+			goto out;
+		}
+
+		if (!len || len > READ_BUF_MAX_AVAIL_LEN) {
+			print_error("illegal len 0x%x entry %d", len, i);
+			goto out;
+		}
+
+		rc = log_ehs_buffer(fd, file, buf, buf_id, len);
+		if (rc) {
+			print_error("log_ehs_buffer buffer id 0x%x", buf_id);
+			goto out;
+		}
+	}
+
+	rc = 0;
+out:
+	if (buf)
+		free(buf);
+
+	if (file != -1)
+		close(file);
+	return rc;
+}
+
+static int decode_ehs_directory(struct ehs_directory_buffer *ehs_dir,
+				__u8 *buffers_cnt)
+{
+	int rc = -EINVAL;
+	u_int16_t length = 0;
+
+	if (!ehs_dir)
+		goto out;
+
+	length = be16toh(ehs_dir->hdr.length);
+	if (!length || length % sizeof(struct ehs_directory_entry)) {
+		print_error("Illegal directory length 0x%x", length);
+		goto out;
+	}
+
+	*buffers_cnt = length / sizeof(struct ehs_directory_entry);
+	if (*buffers_cnt > EHS_MAX_ENTRIES) {
+		print_error("Illegal buffers count %d", *buffers_cnt);
+		goto out;
+	}
+
+	rc = 0;
+out:
+	return rc;
+}
+
+int do_err_hist(struct tool_options *opt)
+{
+	int rc = INVALID;
+	int fd;
+	__u8 *ehs_buf = NULL;
+	struct ehs_directory_buffer *ehs_dir = NULL;
+	__u8 ehs_buffer_cnt = 0;
+
+	fd = open(opt->path, O_RDWR | O_SYNC);
+	if (fd < 0) {
+		perror("open");
+		return ERROR;
+	}
+
+	WRITE_LOG("Start : %s cmd type %d", __func__, opt->idn);
+	ehs_buf = calloc(1, EHS_DIR_ALLOC_LEN);
+	if (!ehs_buf) {
+		rc = -ENOMEM;
+		goto out;
+	}
+
+	rc = read_buffer(fd, ehs_buf, BUFFER_EHS_MODE, 0, 0,
+			EHS_DIR_ALLOC_LEN);
+	if (rc)
+		goto out;
+
+	rc = write_file("error_history_directory.dat", ehs_buf,
+			EHS_DIR_ALLOC_LEN);
+	if (rc)
+		goto out;
+
+	printf("error_history_directory.dat is created\n");
+
+	ehs_dir = (struct ehs_directory_buffer *)ehs_buf;
+	rc = decode_ehs_directory(ehs_dir, &ehs_buffer_cnt);
+	if (rc)
+		goto out;
+
+	printf("retrieving error history, this may take a while\n\n");
+	rc = log_error_history(fd, ehs_dir->entries, ehs_buffer_cnt);
+	if (rc)
+		goto out;
+
+	printf("\nerror_history.dat is created\n");
+
+out:
+	if (ehs_buf)
+		free(ehs_buf);
+	close(fd);
+
+	return rc;
+}
+
+void err_hist_help(char *tool_name)
+{
+	printf("\n Error history command usage:\n");
+	printf("\n\t%s err_hist [-p] <path to device> \n", tool_name);
+	printf("\n\t-p\tPath to the bsg device\n");
+}

--- a/ufs_err_hist.h
+++ b/ufs_err_hist.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* Copyright (C) 2019 Western Digital Corporation or its affiliates */
+
+#ifndef UFS_ERR_HIST_H_
+#define UFS_ERR_HIST_H_
+#include "options.h"
+
+void err_hist_help(char *tool_name);
+int do_err_hist(struct tool_options *opt);
+#endif /*UFS_ERR_HIST_H_*/


### PR DESCRIPTION
UFS3.0 (UFSv3.0 JESD220D spec.) allows to retrieve the error history
by using the READ BUFFER command.

Change-Id: Iaf61fe8d900d1e0393882c6e790987e0cba90ed4