### PR TITLE
ufs-tool: rpmb: add RPMB unit access support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ objects = \
 	scsi_bsg_util.o \
 	ufs_err_hist.o \
 	unipro.o \
-	ufs_ffu.o
+	ufs_ffu.o \
+	rpmb.o \
+	hmac_sha/hmac_sha2.o \
+	hmac_sha/sha2.o
 
 CHECKFLAGS = -Wall  -Wundef
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UFS Tool ver 1.3 #
+# UFS Tool ver 1.4 #
 
 ## Description: ##
 a) Read/Write device flags, attributes & descriptors by
@@ -10,6 +10,7 @@ applied:
 b) Error History   
 c) Get/Set UNIPRO attributes   
 d) FFU - Field Firmware Update   
+e) UFS RPMB unit read/write    
 The tool is aligned to the UFS 3.0 spec.   
 
 ## Build: ##
@@ -35,7 +36,7 @@ Output:
         ufs-tool -v
                 Show the version.
 
-        ufs-tool <desc | attr | fl | err_hist | uic | ffu> --help|-h
+        ufs-tool <desc | attr | fl | err_hist | uic | ffu | rpmb> --help|-h
                 Show detailed help for a command
 
     Run the tool's help for the ufs configuration features in order to
@@ -76,8 +77,8 @@ Output:
                 ufs-tool fl -t 4 -p /dev/block/ufs-bsg
 
 ## Authors ##
-signed-off-by:Arthur Simchaev (arthur.simchaev@wdc.com)
-signed-off-by:Avri Altman (avri.altman@wdc.com)
+signed-off-by:Arthur Simchaev (arthur.simchaev@wdc.com)    
+signed-off-by:Avri Altman (avri.altman@wdc.com)    
 
 ## License ##
 This project is licensed under the GPL-2.0-only  

--- a/hmac_sha/hmac_sha2.c
+++ b/hmac_sha/hmac_sha2.c
@@ -1,0 +1,548 @@
+/*
+ * HMAC-SHA-224/256/384/512 implementation
+ * Last update: 06/15/2005
+ * Issue date:  06/15/2005
+ *
+ * Since this code has been incorporated into a GPLv2 project, it is
+ * distributed under GPLv2 inside mmc-utils.  The original BSD license
+ * that the code was released under is included below for clarity.
+ *
+ * Copyright (C) 2005 Olivier Gay <olivier.gay@a3.epfl.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+#include "hmac_sha2.h"
+
+/* HMAC-SHA-224 functions */
+
+void hmac_sha224_init(hmac_sha224_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size)
+{
+    unsigned int fill;
+    unsigned int num;
+
+    const unsigned char *key_used;
+    unsigned char key_temp[SHA224_DIGEST_SIZE];
+    int i;
+
+    if (key_size == SHA224_BLOCK_SIZE) {
+        key_used = key;
+        num = SHA224_BLOCK_SIZE;
+    } else {
+        if (key_size > SHA224_BLOCK_SIZE){
+            num = SHA224_DIGEST_SIZE;
+            sha224(key, key_size, key_temp);
+            key_used = key_temp;
+        } else { /* key_size > SHA224_BLOCK_SIZE */
+            key_used = key;
+            num = key_size;
+        }
+        fill = SHA224_BLOCK_SIZE - num;
+
+        memset(ctx->block_ipad + num, 0x36, fill);
+        memset(ctx->block_opad + num, 0x5c, fill);
+    }
+
+    for (i = 0; i < (int) num; i++) {
+        ctx->block_ipad[i] = key_used[i] ^ 0x36;
+        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+    }
+
+    sha224_init(&ctx->ctx_inside);
+    sha224_update(&ctx->ctx_inside, ctx->block_ipad, SHA224_BLOCK_SIZE);
+
+    sha224_init(&ctx->ctx_outside);
+    sha224_update(&ctx->ctx_outside, ctx->block_opad,
+                  SHA224_BLOCK_SIZE);
+
+    /* for hmac_reinit */
+    memcpy(&ctx->ctx_inside_reinit, &ctx->ctx_inside,
+           sizeof(sha224_ctx));
+    memcpy(&ctx->ctx_outside_reinit, &ctx->ctx_outside,
+           sizeof(sha224_ctx));
+}
+
+void hmac_sha224_reinit(hmac_sha224_ctx *ctx)
+{
+    memcpy(&ctx->ctx_inside, &ctx->ctx_inside_reinit,
+           sizeof(sha224_ctx));
+    memcpy(&ctx->ctx_outside, &ctx->ctx_outside_reinit,
+           sizeof(sha224_ctx));
+}
+
+void hmac_sha224_update(hmac_sha224_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len)
+{
+    sha224_update(&ctx->ctx_inside, message, message_len);
+}
+
+void hmac_sha224_final(hmac_sha224_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size)
+{
+    unsigned char digest_inside[SHA224_DIGEST_SIZE];
+    unsigned char mac_temp[SHA224_DIGEST_SIZE];
+
+    sha224_final(&ctx->ctx_inside, digest_inside);
+    sha224_update(&ctx->ctx_outside, digest_inside, SHA224_DIGEST_SIZE);
+    sha224_final(&ctx->ctx_outside, mac_temp);
+    memcpy(mac, mac_temp, mac_size);
+}
+
+void hmac_sha224(const unsigned char *key, unsigned int key_size,
+          const unsigned char *message, unsigned int message_len,
+          unsigned char *mac, unsigned mac_size)
+{
+    hmac_sha224_ctx ctx;
+
+    hmac_sha224_init(&ctx, key, key_size);
+    hmac_sha224_update(&ctx, message, message_len);
+    hmac_sha224_final(&ctx, mac, mac_size);
+}
+
+/* HMAC-SHA-256 functions */
+
+void hmac_sha256_init(hmac_sha256_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size)
+{
+    unsigned int fill;
+    unsigned int num;
+
+    const unsigned char *key_used;
+    unsigned char key_temp[SHA256_DIGEST_SIZE];
+    int i;
+
+    if (key_size == SHA256_BLOCK_SIZE) {
+        key_used = key;
+        num = SHA256_BLOCK_SIZE;
+    } else {
+        if (key_size > SHA256_BLOCK_SIZE){
+            num = SHA256_DIGEST_SIZE;
+            sha256(key, key_size, key_temp);
+            key_used = key_temp;
+        } else { /* key_size > SHA256_BLOCK_SIZE */
+            key_used = key;
+            num = key_size;
+        }
+        fill = SHA256_BLOCK_SIZE - num;
+
+        memset(ctx->block_ipad + num, 0x36, fill);
+        memset(ctx->block_opad + num, 0x5c, fill);
+    }
+
+    for (i = 0; i < (int) num; i++) {
+        ctx->block_ipad[i] = key_used[i] ^ 0x36;
+        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+    }
+
+    sha256_init(&ctx->ctx_inside);
+    sha256_update(&ctx->ctx_inside, ctx->block_ipad, SHA256_BLOCK_SIZE);
+
+    sha256_init(&ctx->ctx_outside);
+    sha256_update(&ctx->ctx_outside, ctx->block_opad,
+                  SHA256_BLOCK_SIZE);
+
+    /* for hmac_reinit */
+    memcpy(&ctx->ctx_inside_reinit, &ctx->ctx_inside,
+           sizeof(sha256_ctx));
+    memcpy(&ctx->ctx_outside_reinit, &ctx->ctx_outside,
+           sizeof(sha256_ctx));
+}
+
+void hmac_sha256_reinit(hmac_sha256_ctx *ctx)
+{
+    memcpy(&ctx->ctx_inside, &ctx->ctx_inside_reinit,
+           sizeof(sha256_ctx));
+    memcpy(&ctx->ctx_outside, &ctx->ctx_outside_reinit,
+           sizeof(sha256_ctx));
+}
+
+void hmac_sha256_update(hmac_sha256_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len)
+{
+    sha256_update(&ctx->ctx_inside, message, message_len);
+}
+
+void hmac_sha256_final(hmac_sha256_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size)
+{
+    unsigned char digest_inside[SHA256_DIGEST_SIZE];
+    unsigned char mac_temp[SHA256_DIGEST_SIZE];
+
+    sha256_final(&ctx->ctx_inside, digest_inside);
+    sha256_update(&ctx->ctx_outside, digest_inside, SHA256_DIGEST_SIZE);
+    sha256_final(&ctx->ctx_outside, mac_temp);
+    memcpy(mac, mac_temp, mac_size);
+}
+
+void hmac_sha256(const unsigned char *key, unsigned int key_size,
+          const unsigned char *message, unsigned int message_len,
+          unsigned char *mac, unsigned mac_size)
+{
+    hmac_sha256_ctx ctx;
+
+    hmac_sha256_init(&ctx, key, key_size);
+    hmac_sha256_update(&ctx, message, message_len);
+    hmac_sha256_final(&ctx, mac, mac_size);
+}
+
+/* HMAC-SHA-384 functions */
+
+void hmac_sha384_init(hmac_sha384_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size)
+{
+    unsigned int fill;
+    unsigned int num;
+
+    const unsigned char *key_used;
+    unsigned char key_temp[SHA384_DIGEST_SIZE];
+    int i;
+
+    if (key_size == SHA384_BLOCK_SIZE) {
+        key_used = key;
+        num = SHA384_BLOCK_SIZE;
+    } else {
+        if (key_size > SHA384_BLOCK_SIZE){
+            num = SHA384_DIGEST_SIZE;
+            sha384(key, key_size, key_temp);
+            key_used = key_temp;
+        } else { /* key_size > SHA384_BLOCK_SIZE */
+            key_used = key;
+            num = key_size;
+        }
+        fill = SHA384_BLOCK_SIZE - num;
+
+        memset(ctx->block_ipad + num, 0x36, fill);
+        memset(ctx->block_opad + num, 0x5c, fill);
+    }
+
+    for (i = 0; i < (int) num; i++) {
+        ctx->block_ipad[i] = key_used[i] ^ 0x36;
+        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+    }
+
+    sha384_init(&ctx->ctx_inside);
+    sha384_update(&ctx->ctx_inside, ctx->block_ipad, SHA384_BLOCK_SIZE);
+
+    sha384_init(&ctx->ctx_outside);
+    sha384_update(&ctx->ctx_outside, ctx->block_opad,
+                  SHA384_BLOCK_SIZE);
+
+    /* for hmac_reinit */
+    memcpy(&ctx->ctx_inside_reinit, &ctx->ctx_inside,
+           sizeof(sha384_ctx));
+    memcpy(&ctx->ctx_outside_reinit, &ctx->ctx_outside,
+           sizeof(sha384_ctx));
+}
+
+void hmac_sha384_reinit(hmac_sha384_ctx *ctx)
+{
+    memcpy(&ctx->ctx_inside, &ctx->ctx_inside_reinit,
+           sizeof(sha384_ctx));
+    memcpy(&ctx->ctx_outside, &ctx->ctx_outside_reinit,
+           sizeof(sha384_ctx));
+}
+
+void hmac_sha384_update(hmac_sha384_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len)
+{
+    sha384_update(&ctx->ctx_inside, message, message_len);
+}
+
+void hmac_sha384_final(hmac_sha384_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size)
+{
+    unsigned char digest_inside[SHA384_DIGEST_SIZE];
+    unsigned char mac_temp[SHA384_DIGEST_SIZE];
+
+    sha384_final(&ctx->ctx_inside, digest_inside);
+    sha384_update(&ctx->ctx_outside, digest_inside, SHA384_DIGEST_SIZE);
+    sha384_final(&ctx->ctx_outside, mac_temp);
+    memcpy(mac, mac_temp, mac_size);
+}
+
+void hmac_sha384(const unsigned char *key, unsigned int key_size,
+          const unsigned char *message, unsigned int message_len,
+          unsigned char *mac, unsigned mac_size)
+{
+    hmac_sha384_ctx ctx;
+
+    hmac_sha384_init(&ctx, key, key_size);
+    hmac_sha384_update(&ctx, message, message_len);
+    hmac_sha384_final(&ctx, mac, mac_size);
+}
+
+/* HMAC-SHA-512 functions */
+
+void hmac_sha512_init(hmac_sha512_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size)
+{
+    unsigned int fill;
+    unsigned int num;
+
+    const unsigned char *key_used;
+    unsigned char key_temp[SHA512_DIGEST_SIZE];
+    int i;
+
+    if (key_size == SHA512_BLOCK_SIZE) {
+        key_used = key;
+        num = SHA512_BLOCK_SIZE;
+    } else {
+        if (key_size > SHA512_BLOCK_SIZE){
+            num = SHA512_DIGEST_SIZE;
+            sha512(key, key_size, key_temp);
+            key_used = key_temp;
+        } else { /* key_size > SHA512_BLOCK_SIZE */
+            key_used = key;
+            num = key_size;
+        }
+        fill = SHA512_BLOCK_SIZE - num;
+
+        memset(ctx->block_ipad + num, 0x36, fill);
+        memset(ctx->block_opad + num, 0x5c, fill);
+    }
+
+    for (i = 0; i < (int) num; i++) {
+        ctx->block_ipad[i] = key_used[i] ^ 0x36;
+        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+    }
+
+    sha512_init(&ctx->ctx_inside);
+    sha512_update(&ctx->ctx_inside, ctx->block_ipad, SHA512_BLOCK_SIZE);
+
+    sha512_init(&ctx->ctx_outside);
+    sha512_update(&ctx->ctx_outside, ctx->block_opad,
+                  SHA512_BLOCK_SIZE);
+
+    /* for hmac_reinit */
+    memcpy(&ctx->ctx_inside_reinit, &ctx->ctx_inside,
+           sizeof(sha512_ctx));
+    memcpy(&ctx->ctx_outside_reinit, &ctx->ctx_outside,
+           sizeof(sha512_ctx));
+}
+
+void hmac_sha512_reinit(hmac_sha512_ctx *ctx)
+{
+    memcpy(&ctx->ctx_inside, &ctx->ctx_inside_reinit,
+           sizeof(sha512_ctx));
+    memcpy(&ctx->ctx_outside, &ctx->ctx_outside_reinit,
+           sizeof(sha512_ctx));
+}
+
+void hmac_sha512_update(hmac_sha512_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len)
+{
+    sha512_update(&ctx->ctx_inside, message, message_len);
+}
+
+void hmac_sha512_final(hmac_sha512_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size)
+{
+    unsigned char digest_inside[SHA512_DIGEST_SIZE];
+    unsigned char mac_temp[SHA512_DIGEST_SIZE];
+
+    sha512_final(&ctx->ctx_inside, digest_inside);
+    sha512_update(&ctx->ctx_outside, digest_inside, SHA512_DIGEST_SIZE);
+    sha512_final(&ctx->ctx_outside, mac_temp);
+    memcpy(mac, mac_temp, mac_size);
+}
+
+void hmac_sha512(const unsigned char *key, unsigned int key_size,
+          const unsigned char *message, unsigned int message_len,
+          unsigned char *mac, unsigned mac_size)
+{
+    hmac_sha512_ctx ctx;
+
+    hmac_sha512_init(&ctx, key, key_size);
+    hmac_sha512_update(&ctx, message, message_len);
+    hmac_sha512_final(&ctx, mac, mac_size);
+}
+
+#ifdef TEST_VECTORS
+
+/* IETF Validation tests */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void test(const char *vector, unsigned char *digest,
+          unsigned int digest_size)
+{
+    char output[2 * SHA512_DIGEST_SIZE + 1];
+    int i;
+
+    output[2 * digest_size] = '\0';
+
+    for (i = 0; i < (int) digest_size ; i++) {
+       sprintf(output + 2*i, "%02x", digest[i]);
+    }
+
+    printf("H: %s\n", output);
+    if (strcmp(vector, output)) {
+        fprintf(stderr, "Test failed.\n");
+        exit(1);
+    }
+}
+
+int main(void)
+{
+    static const char *vectors[] =
+    {
+        /* HMAC-SHA-224 */
+        "896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22",
+        "a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44",
+        "7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea",
+        "6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a",
+        "0e2aea68a90c8d37c988bcdb9fca6fa8",
+        "95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e",
+        "3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1",
+        /* HMAC-SHA-256 */
+        "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+        "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+        "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe",
+        "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b",
+        "a3b6167473100ee06e0c796c2955552b",
+        "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54",
+        "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2",
+        /* HMAC-SHA-384 */
+        "afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59c"
+        "faea9ea9076ede7f4af152e8b2fa9cb6",
+        "af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e"
+        "8e2240ca5e69e2c78b3239ecfab21649",
+        "88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b"
+        "2a5ab39dc13814b94e3ab6e101a34f27",
+        "3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e"
+        "6801dd23c4a7d679ccf8a386c674cffb",
+        "3abf34c3503b2a23a46efc619baef897",
+        "4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c6"
+        "0c2ef6ab4030fe8296248df163f44952",
+        "6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5"
+        "a678cc31e799176d3860e6110c46523e",
+        /* HMAC-SHA-512 */
+        "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde"
+        "daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854",
+        "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea250554"
+        "9758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737",
+        "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39"
+        "bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb",
+        "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3db"
+        "a91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd",
+        "415fad6271580a531d4179bc891d87a6",
+        "80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f352"
+        "6b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598",
+        "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944"
+        "b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58"
+    };
+
+    static char *messages[] =
+    {
+        "Hi There",
+        "what do ya want for nothing?",
+        NULL,
+        NULL,
+        "Test With Truncation",
+        "Test Using Larger Than Block-Size Key - Hash Key First",
+        "This is a test using a larger than block-size key "
+        "and a larger than block-size data. The key needs"
+        " to be hashed before being used by the HMAC algorithm."
+    };
+
+    unsigned char mac[SHA512_DIGEST_SIZE];
+    unsigned char *keys[7];
+    unsigned int keys_len[7] = {20, 4, 20, 25, 20, 131, 131};
+    unsigned int messages2and3_len = 50;
+    unsigned int mac_224_size, mac_256_size, mac_384_size, mac_512_size;
+    int i;
+
+    for (i = 0; i < 7; i++) {
+        keys[i] = malloc(keys_len[i]);
+        if (keys[i] == NULL) {
+            fprintf(stderr, "Can't allocate memory\n");
+            return 1;
+        }
+    }
+
+    memset(keys[0], 0x0b, keys_len[0]);
+    strcpy((char *) keys[1], "Jefe");
+    memset(keys[2], 0xaa, keys_len[2]);
+    for (i = 0; i < (int) keys_len[3]; i++)
+        keys[3][i] = (unsigned char) i + 1;
+    memset(keys[4], 0x0c, keys_len[4]);
+    memset(keys[5], 0xaa, keys_len[5]);
+    memset(keys[6], 0xaa, keys_len[6]);
+
+    messages[2] = malloc(messages2and3_len + 1);
+    messages[3] = malloc(messages2and3_len + 1);
+
+    if (messages[2] == NULL || messages[3] == NULL) {
+        fprintf(stderr, "Can't allocate memory\n");
+        return 1;
+    }
+
+    messages[2][messages2and3_len] = '\0';
+    messages[3][messages2and3_len] = '\0';
+
+    memset(messages[2], 0xdd, messages2and3_len);
+    memset(messages[3], 0xcd, messages2and3_len);
+
+    printf("HMAC-SHA-2 IETF Validation tests\n\n");
+
+    for (i = 0; i < 7; i++) {
+        if (i != 4) {
+            mac_224_size = SHA224_DIGEST_SIZE;
+            mac_256_size = SHA256_DIGEST_SIZE;
+            mac_384_size = SHA384_DIGEST_SIZE;
+            mac_512_size = SHA512_DIGEST_SIZE;
+        } else {
+            mac_224_size = 128 / 8; mac_256_size = 128 / 8;
+            mac_384_size = 128 / 8; mac_512_size = 128 / 8;
+        }
+
+        printf("Test %d:\n", i + 1);
+
+        hmac_sha224(keys[i], keys_len[i], (unsigned char *) messages[i],
+                    strlen(messages[i]), mac, mac_224_size);
+        test(vectors[i], mac, mac_224_size);
+        hmac_sha256(keys[i], keys_len[i], (unsigned char *) messages[i],
+                    strlen(messages[i]), mac, mac_256_size);
+        test(vectors[7 + i], mac, mac_256_size);
+        hmac_sha384(keys[i], keys_len[i], (unsigned char *) messages[i],
+                    strlen(messages[i]), mac, mac_384_size);
+        test(vectors[14 + i], mac, mac_384_size);
+        hmac_sha512(keys[i], keys_len[i], (unsigned char *) messages[i],
+                    strlen(messages[i]), mac, mac_512_size);
+        test(vectors[21 + i], mac, mac_512_size);
+    }
+
+    printf("All tests passed.\n");
+
+    return 0;
+}
+
+#endif /* TEST_VECTORS */
+

--- a/hmac_sha/hmac_sha2.h
+++ b/hmac_sha/hmac_sha2.h
@@ -1,0 +1,144 @@
+/*
+ * HMAC-SHA-224/256/384/512 implementation
+ * Last update: 06/15/2005
+ * Issue date:  06/15/2005
+ *
+ * Since this code has been incorporated into a GPLv2 project, it is
+ * distributed under GPLv2 inside mmc-utils.  The original BSD license
+ * that the code was released under is included below for clarity.
+ *
+ * Copyright (C) 2005 Olivier Gay <olivier.gay@a3.epfl.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef HMAC_SHA2_H
+#define HMAC_SHA2_H
+
+#include "sha2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    sha224_ctx ctx_inside;
+    sha224_ctx ctx_outside;
+
+    /* for hmac_reinit */
+    sha224_ctx ctx_inside_reinit;
+    sha224_ctx ctx_outside_reinit;
+
+    unsigned char block_ipad[SHA224_BLOCK_SIZE];
+    unsigned char block_opad[SHA224_BLOCK_SIZE];
+} hmac_sha224_ctx;
+
+typedef struct {
+    sha256_ctx ctx_inside;
+    sha256_ctx ctx_outside;
+
+    /* for hmac_reinit */
+    sha256_ctx ctx_inside_reinit;
+    sha256_ctx ctx_outside_reinit;
+
+    unsigned char block_ipad[SHA256_BLOCK_SIZE];
+    unsigned char block_opad[SHA256_BLOCK_SIZE];
+} hmac_sha256_ctx;
+
+typedef struct {
+    sha384_ctx ctx_inside;
+    sha384_ctx ctx_outside;
+
+    /* for hmac_reinit */
+    sha384_ctx ctx_inside_reinit;
+    sha384_ctx ctx_outside_reinit;
+
+    unsigned char block_ipad[SHA384_BLOCK_SIZE];
+    unsigned char block_opad[SHA384_BLOCK_SIZE];
+} hmac_sha384_ctx;
+
+typedef struct {
+    sha512_ctx ctx_inside;
+    sha512_ctx ctx_outside;
+
+    /* for hmac_reinit */
+    sha512_ctx ctx_inside_reinit;
+    sha512_ctx ctx_outside_reinit;
+
+    unsigned char block_ipad[SHA512_BLOCK_SIZE];
+    unsigned char block_opad[SHA512_BLOCK_SIZE];
+} hmac_sha512_ctx;
+
+void hmac_sha224_init(hmac_sha224_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size);
+void hmac_sha224_reinit(hmac_sha224_ctx *ctx);
+void hmac_sha224_update(hmac_sha224_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len);
+void hmac_sha224_final(hmac_sha224_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size);
+void hmac_sha224(const unsigned char *key, unsigned int key_size,
+                 const unsigned char *message, unsigned int message_len,
+                 unsigned char *mac, unsigned mac_size);
+
+void hmac_sha256_init(hmac_sha256_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size);
+void hmac_sha256_reinit(hmac_sha256_ctx *ctx);
+void hmac_sha256_update(hmac_sha256_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len);
+void hmac_sha256_final(hmac_sha256_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size);
+void hmac_sha256(const unsigned char *key, unsigned int key_size,
+                 const unsigned char *message, unsigned int message_len,
+                 unsigned char *mac, unsigned mac_size);
+
+void hmac_sha384_init(hmac_sha384_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size);
+void hmac_sha384_reinit(hmac_sha384_ctx *ctx);
+void hmac_sha384_update(hmac_sha384_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len);
+void hmac_sha384_final(hmac_sha384_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size);
+void hmac_sha384(const unsigned char *key, unsigned int key_size,
+                 const unsigned char *message, unsigned int message_len,
+                 unsigned char *mac, unsigned mac_size);
+
+void hmac_sha512_init(hmac_sha512_ctx *ctx, const unsigned char *key,
+                      unsigned int key_size);
+void hmac_sha512_reinit(hmac_sha512_ctx *ctx);
+void hmac_sha512_update(hmac_sha512_ctx *ctx, const unsigned char *message,
+                        unsigned int message_len);
+void hmac_sha512_final(hmac_sha512_ctx *ctx, unsigned char *mac,
+                       unsigned int mac_size);
+void hmac_sha512(const unsigned char *key, unsigned int key_size,
+                 const unsigned char *message, unsigned int message_len,
+                 unsigned char *mac, unsigned mac_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !HMAC_SHA2_H */
+

--- a/hmac_sha/sha2.c
+++ b/hmac_sha/sha2.c
@@ -1,0 +1,953 @@
+/*
+ * FIPS 180-2 SHA-224/256/384/512 implementation
+ * Last update: 02/02/2007
+ * Issue date:  04/30/2005
+ *
+ * Since this code has been incorporated into a GPLv2 project, it is
+ * distributed under GPLv2 inside mmc-utils.  The original BSD license
+ * that the code was released under is included below for clarity.
+ *
+ * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if 0
+#define UNROLL_LOOPS /* Enable loops unrolling */
+#endif
+
+#include <string.h>
+
+#include "sha2.h"
+
+#define SHFR(x, n)    (x >> n)
+#define ROTR(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
+#define ROTL(x, n)   ((x << n) | (x >> ((sizeof(x) << 3) - n)))
+#define CH(x, y, z)  ((x & y) ^ (~x & z))
+#define MAJ(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+
+#define SHA256_F1(x) (ROTR(x,  2) ^ ROTR(x, 13) ^ ROTR(x, 22))
+#define SHA256_F2(x) (ROTR(x,  6) ^ ROTR(x, 11) ^ ROTR(x, 25))
+#define SHA256_F3(x) (ROTR(x,  7) ^ ROTR(x, 18) ^ SHFR(x,  3))
+#define SHA256_F4(x) (ROTR(x, 17) ^ ROTR(x, 19) ^ SHFR(x, 10))
+
+#define SHA512_F1(x) (ROTR(x, 28) ^ ROTR(x, 34) ^ ROTR(x, 39))
+#define SHA512_F2(x) (ROTR(x, 14) ^ ROTR(x, 18) ^ ROTR(x, 41))
+#define SHA512_F3(x) (ROTR(x,  1) ^ ROTR(x,  8) ^ SHFR(x,  7))
+#define SHA512_F4(x) (ROTR(x, 19) ^ ROTR(x, 61) ^ SHFR(x,  6))
+
+#define UNPACK32(x, str)                      \
+{                                             \
+    *((str) + 3) = (uint8) ((x)      );       \
+    *((str) + 2) = (uint8) ((x) >>  8);       \
+    *((str) + 1) = (uint8) ((x) >> 16);       \
+    *((str) + 0) = (uint8) ((x) >> 24);       \
+}
+
+#define PACK32(str, x)                        \
+{                                             \
+    *(x) =   ((uint32) *((str) + 3)      )    \
+           | ((uint32) *((str) + 2) <<  8)    \
+           | ((uint32) *((str) + 1) << 16)    \
+           | ((uint32) *((str) + 0) << 24);   \
+}
+
+#define UNPACK64(x, str)                      \
+{                                             \
+    *((str) + 7) = (uint8) ((x)      );       \
+    *((str) + 6) = (uint8) ((x) >>  8);       \
+    *((str) + 5) = (uint8) ((x) >> 16);       \
+    *((str) + 4) = (uint8) ((x) >> 24);       \
+    *((str) + 3) = (uint8) ((x) >> 32);       \
+    *((str) + 2) = (uint8) ((x) >> 40);       \
+    *((str) + 1) = (uint8) ((x) >> 48);       \
+    *((str) + 0) = (uint8) ((x) >> 56);       \
+}
+
+#define PACK64(str, x)                        \
+{                                             \
+    *(x) =   ((uint64) *((str) + 7)      )    \
+           | ((uint64) *((str) + 6) <<  8)    \
+           | ((uint64) *((str) + 5) << 16)    \
+           | ((uint64) *((str) + 4) << 24)    \
+           | ((uint64) *((str) + 3) << 32)    \
+           | ((uint64) *((str) + 2) << 40)    \
+           | ((uint64) *((str) + 1) << 48)    \
+           | ((uint64) *((str) + 0) << 56);   \
+}
+
+/* Macros used for loops unrolling */
+
+#define SHA256_SCR(i)                         \
+{                                             \
+    w[i] =  SHA256_F4(w[i -  2]) + w[i -  7]  \
+          + SHA256_F3(w[i - 15]) + w[i - 16]; \
+}
+
+#define SHA512_SCR(i)                         \
+{                                             \
+    w[i] =  SHA512_F4(w[i -  2]) + w[i -  7]  \
+          + SHA512_F3(w[i - 15]) + w[i - 16]; \
+}
+
+#define SHA256_EXP(a, b, c, d, e, f, g, h, j)               \
+{                                                           \
+    t1 = wv[h] + SHA256_F2(wv[e]) + CH(wv[e], wv[f], wv[g]) \
+         + sha256_k[j] + w[j];                              \
+    t2 = SHA256_F1(wv[a]) + MAJ(wv[a], wv[b], wv[c]);       \
+    wv[d] += t1;                                            \
+    wv[h] = t1 + t2;                                        \
+}
+
+#define SHA512_EXP(a, b, c, d, e, f, g ,h, j)               \
+{                                                           \
+    t1 = wv[h] + SHA512_F2(wv[e]) + CH(wv[e], wv[f], wv[g]) \
+         + sha512_k[j] + w[j];                              \
+    t2 = SHA512_F1(wv[a]) + MAJ(wv[a], wv[b], wv[c]);       \
+    wv[d] += t1;                                            \
+    wv[h] = t1 + t2;                                        \
+}
+
+uint32 sha224_h0[8] =
+            {0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
+             0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4};
+
+uint32 sha256_h0[8] =
+            {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+             0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+uint64 sha384_h0[8] =
+            {0xcbbb9d5dc1059ed8ULL, 0x629a292a367cd507ULL,
+             0x9159015a3070dd17ULL, 0x152fecd8f70e5939ULL,
+             0x67332667ffc00b31ULL, 0x8eb44a8768581511ULL,
+             0xdb0c2e0d64f98fa7ULL, 0x47b5481dbefa4fa4ULL};
+
+uint64 sha512_h0[8] =
+            {0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL,
+             0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+             0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+             0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL};
+
+uint32 sha256_k[64] =
+            {0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+             0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+             0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+             0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+             0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+             0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+             0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+             0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+             0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+             0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+             0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+             0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+             0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+             0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+             0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+             0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+uint64 sha512_k[80] =
+            {0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL,
+             0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
+             0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
+             0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
+             0xd807aa98a3030242ULL, 0x12835b0145706fbeULL,
+             0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+             0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL,
+             0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
+             0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL,
+             0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+             0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL,
+             0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+             0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL,
+             0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
+             0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
+             0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
+             0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL,
+             0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+             0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL,
+             0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+             0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL,
+             0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
+             0xd192e819d6ef5218ULL, 0xd69906245565a910ULL,
+             0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+             0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL,
+             0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
+             0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL,
+             0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
+             0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL,
+             0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+             0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL,
+             0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
+             0xca273eceea26619cULL, 0xd186b8c721c0c207ULL,
+             0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
+             0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL,
+             0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+             0x28db77f523047d84ULL, 0x32caab7b40c72493ULL,
+             0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
+             0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL,
+             0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL};
+
+/* SHA-256 functions */
+
+void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
+                   unsigned int block_nb)
+{
+    uint32 w[64];
+    uint32 wv[8];
+    uint32 t1, t2;
+    const unsigned char *sub_block;
+    int i;
+
+#ifndef UNROLL_LOOPS
+    int j;
+#endif
+
+    for (i = 0; i < (int) block_nb; i++) {
+        sub_block = message + (i << 6);
+
+#ifndef UNROLL_LOOPS
+        for (j = 0; j < 16; j++) {
+            PACK32(&sub_block[j << 2], &w[j]);
+        }
+
+        for (j = 16; j < 64; j++) {
+            SHA256_SCR(j);
+        }
+
+        for (j = 0; j < 8; j++) {
+            wv[j] = ctx->h[j];
+        }
+
+        for (j = 0; j < 64; j++) {
+            t1 = wv[7] + SHA256_F2(wv[4]) + CH(wv[4], wv[5], wv[6])
+                + sha256_k[j] + w[j];
+            t2 = SHA256_F1(wv[0]) + MAJ(wv[0], wv[1], wv[2]);
+            wv[7] = wv[6];
+            wv[6] = wv[5];
+            wv[5] = wv[4];
+            wv[4] = wv[3] + t1;
+            wv[3] = wv[2];
+            wv[2] = wv[1];
+            wv[1] = wv[0];
+            wv[0] = t1 + t2;
+        }
+
+        for (j = 0; j < 8; j++) {
+            ctx->h[j] += wv[j];
+        }
+#else
+        PACK32(&sub_block[ 0], &w[ 0]); PACK32(&sub_block[ 4], &w[ 1]);
+        PACK32(&sub_block[ 8], &w[ 2]); PACK32(&sub_block[12], &w[ 3]);
+        PACK32(&sub_block[16], &w[ 4]); PACK32(&sub_block[20], &w[ 5]);
+        PACK32(&sub_block[24], &w[ 6]); PACK32(&sub_block[28], &w[ 7]);
+        PACK32(&sub_block[32], &w[ 8]); PACK32(&sub_block[36], &w[ 9]);
+        PACK32(&sub_block[40], &w[10]); PACK32(&sub_block[44], &w[11]);
+        PACK32(&sub_block[48], &w[12]); PACK32(&sub_block[52], &w[13]);
+        PACK32(&sub_block[56], &w[14]); PACK32(&sub_block[60], &w[15]);
+
+        SHA256_SCR(16); SHA256_SCR(17); SHA256_SCR(18); SHA256_SCR(19);
+        SHA256_SCR(20); SHA256_SCR(21); SHA256_SCR(22); SHA256_SCR(23);
+        SHA256_SCR(24); SHA256_SCR(25); SHA256_SCR(26); SHA256_SCR(27);
+        SHA256_SCR(28); SHA256_SCR(29); SHA256_SCR(30); SHA256_SCR(31);
+        SHA256_SCR(32); SHA256_SCR(33); SHA256_SCR(34); SHA256_SCR(35);
+        SHA256_SCR(36); SHA256_SCR(37); SHA256_SCR(38); SHA256_SCR(39);
+        SHA256_SCR(40); SHA256_SCR(41); SHA256_SCR(42); SHA256_SCR(43);
+        SHA256_SCR(44); SHA256_SCR(45); SHA256_SCR(46); SHA256_SCR(47);
+        SHA256_SCR(48); SHA256_SCR(49); SHA256_SCR(50); SHA256_SCR(51);
+        SHA256_SCR(52); SHA256_SCR(53); SHA256_SCR(54); SHA256_SCR(55);
+        SHA256_SCR(56); SHA256_SCR(57); SHA256_SCR(58); SHA256_SCR(59);
+        SHA256_SCR(60); SHA256_SCR(61); SHA256_SCR(62); SHA256_SCR(63);
+
+        wv[0] = ctx->h[0]; wv[1] = ctx->h[1];
+        wv[2] = ctx->h[2]; wv[3] = ctx->h[3];
+        wv[4] = ctx->h[4]; wv[5] = ctx->h[5];
+        wv[6] = ctx->h[6]; wv[7] = ctx->h[7];
+
+        SHA256_EXP(0,1,2,3,4,5,6,7, 0); SHA256_EXP(7,0,1,2,3,4,5,6, 1);
+        SHA256_EXP(6,7,0,1,2,3,4,5, 2); SHA256_EXP(5,6,7,0,1,2,3,4, 3);
+        SHA256_EXP(4,5,6,7,0,1,2,3, 4); SHA256_EXP(3,4,5,6,7,0,1,2, 5);
+        SHA256_EXP(2,3,4,5,6,7,0,1, 6); SHA256_EXP(1,2,3,4,5,6,7,0, 7);
+        SHA256_EXP(0,1,2,3,4,5,6,7, 8); SHA256_EXP(7,0,1,2,3,4,5,6, 9);
+        SHA256_EXP(6,7,0,1,2,3,4,5,10); SHA256_EXP(5,6,7,0,1,2,3,4,11);
+        SHA256_EXP(4,5,6,7,0,1,2,3,12); SHA256_EXP(3,4,5,6,7,0,1,2,13);
+        SHA256_EXP(2,3,4,5,6,7,0,1,14); SHA256_EXP(1,2,3,4,5,6,7,0,15);
+        SHA256_EXP(0,1,2,3,4,5,6,7,16); SHA256_EXP(7,0,1,2,3,4,5,6,17);
+        SHA256_EXP(6,7,0,1,2,3,4,5,18); SHA256_EXP(5,6,7,0,1,2,3,4,19);
+        SHA256_EXP(4,5,6,7,0,1,2,3,20); SHA256_EXP(3,4,5,6,7,0,1,2,21);
+        SHA256_EXP(2,3,4,5,6,7,0,1,22); SHA256_EXP(1,2,3,4,5,6,7,0,23);
+        SHA256_EXP(0,1,2,3,4,5,6,7,24); SHA256_EXP(7,0,1,2,3,4,5,6,25);
+        SHA256_EXP(6,7,0,1,2,3,4,5,26); SHA256_EXP(5,6,7,0,1,2,3,4,27);
+        SHA256_EXP(4,5,6,7,0,1,2,3,28); SHA256_EXP(3,4,5,6,7,0,1,2,29);
+        SHA256_EXP(2,3,4,5,6,7,0,1,30); SHA256_EXP(1,2,3,4,5,6,7,0,31);
+        SHA256_EXP(0,1,2,3,4,5,6,7,32); SHA256_EXP(7,0,1,2,3,4,5,6,33);
+        SHA256_EXP(6,7,0,1,2,3,4,5,34); SHA256_EXP(5,6,7,0,1,2,3,4,35);
+        SHA256_EXP(4,5,6,7,0,1,2,3,36); SHA256_EXP(3,4,5,6,7,0,1,2,37);
+        SHA256_EXP(2,3,4,5,6,7,0,1,38); SHA256_EXP(1,2,3,4,5,6,7,0,39);
+        SHA256_EXP(0,1,2,3,4,5,6,7,40); SHA256_EXP(7,0,1,2,3,4,5,6,41);
+        SHA256_EXP(6,7,0,1,2,3,4,5,42); SHA256_EXP(5,6,7,0,1,2,3,4,43);
+        SHA256_EXP(4,5,6,7,0,1,2,3,44); SHA256_EXP(3,4,5,6,7,0,1,2,45);
+        SHA256_EXP(2,3,4,5,6,7,0,1,46); SHA256_EXP(1,2,3,4,5,6,7,0,47);
+        SHA256_EXP(0,1,2,3,4,5,6,7,48); SHA256_EXP(7,0,1,2,3,4,5,6,49);
+        SHA256_EXP(6,7,0,1,2,3,4,5,50); SHA256_EXP(5,6,7,0,1,2,3,4,51);
+        SHA256_EXP(4,5,6,7,0,1,2,3,52); SHA256_EXP(3,4,5,6,7,0,1,2,53);
+        SHA256_EXP(2,3,4,5,6,7,0,1,54); SHA256_EXP(1,2,3,4,5,6,7,0,55);
+        SHA256_EXP(0,1,2,3,4,5,6,7,56); SHA256_EXP(7,0,1,2,3,4,5,6,57);
+        SHA256_EXP(6,7,0,1,2,3,4,5,58); SHA256_EXP(5,6,7,0,1,2,3,4,59);
+        SHA256_EXP(4,5,6,7,0,1,2,3,60); SHA256_EXP(3,4,5,6,7,0,1,2,61);
+        SHA256_EXP(2,3,4,5,6,7,0,1,62); SHA256_EXP(1,2,3,4,5,6,7,0,63);
+
+        ctx->h[0] += wv[0]; ctx->h[1] += wv[1];
+        ctx->h[2] += wv[2]; ctx->h[3] += wv[3];
+        ctx->h[4] += wv[4]; ctx->h[5] += wv[5];
+        ctx->h[6] += wv[6]; ctx->h[7] += wv[7];
+#endif /* !UNROLL_LOOPS */
+    }
+}
+
+void sha256(const unsigned char *message, unsigned int len, unsigned char *digest)
+{
+    sha256_ctx ctx;
+
+    sha256_init(&ctx);
+    sha256_update(&ctx, message, len);
+    sha256_final(&ctx, digest);
+}
+
+void sha256_init(sha256_ctx *ctx)
+{
+#ifndef UNROLL_LOOPS
+    int i;
+    for (i = 0; i < 8; i++) {
+        ctx->h[i] = sha256_h0[i];
+    }
+#else
+    ctx->h[0] = sha256_h0[0]; ctx->h[1] = sha256_h0[1];
+    ctx->h[2] = sha256_h0[2]; ctx->h[3] = sha256_h0[3];
+    ctx->h[4] = sha256_h0[4]; ctx->h[5] = sha256_h0[5];
+    ctx->h[6] = sha256_h0[6]; ctx->h[7] = sha256_h0[7];
+#endif /* !UNROLL_LOOPS */
+
+    ctx->len = 0;
+    ctx->tot_len = 0;
+}
+
+void sha256_update(sha256_ctx *ctx, const unsigned char *message,
+                   unsigned int len)
+{
+    unsigned int block_nb;
+    unsigned int new_len, rem_len, tmp_len;
+    const unsigned char *shifted_message;
+
+    tmp_len = SHA256_BLOCK_SIZE - ctx->len;
+    rem_len = len < tmp_len ? len : tmp_len;
+
+    memcpy(&ctx->block[ctx->len], message, rem_len);
+
+    if (ctx->len + len < SHA256_BLOCK_SIZE) {
+        ctx->len += len;
+        return;
+    }
+
+    new_len = len - rem_len;
+    block_nb = new_len / SHA256_BLOCK_SIZE;
+
+    shifted_message = message + rem_len;
+
+    sha256_transf(ctx, ctx->block, 1);
+    sha256_transf(ctx, shifted_message, block_nb);
+
+    rem_len = new_len % SHA256_BLOCK_SIZE;
+
+    memcpy(ctx->block, &shifted_message[block_nb << 6],
+           rem_len);
+
+    ctx->len = rem_len;
+    ctx->tot_len += (block_nb + 1) << 6;
+}
+
+void sha256_final(sha256_ctx *ctx, unsigned char *digest)
+{
+    unsigned int block_nb;
+    unsigned int pm_len;
+    unsigned int len_b;
+
+#ifndef UNROLL_LOOPS
+    int i;
+#endif
+
+    block_nb = (1 + ((SHA256_BLOCK_SIZE - 9)
+                     < (ctx->len % SHA256_BLOCK_SIZE)));
+
+    len_b = (ctx->tot_len + ctx->len) << 3;
+    pm_len = block_nb << 6;
+
+    memset(ctx->block + ctx->len, 0, pm_len - ctx->len);
+    ctx->block[ctx->len] = 0x80;
+    UNPACK32(len_b, ctx->block + pm_len - 4);
+
+    sha256_transf(ctx, ctx->block, block_nb);
+
+#ifndef UNROLL_LOOPS
+    for (i = 0 ; i < 8; i++) {
+        UNPACK32(ctx->h[i], &digest[i << 2]);
+    }
+#else
+   UNPACK32(ctx->h[0], &digest[ 0]);
+   UNPACK32(ctx->h[1], &digest[ 4]);
+   UNPACK32(ctx->h[2], &digest[ 8]);
+   UNPACK32(ctx->h[3], &digest[12]);
+   UNPACK32(ctx->h[4], &digest[16]);
+   UNPACK32(ctx->h[5], &digest[20]);
+   UNPACK32(ctx->h[6], &digest[24]);
+   UNPACK32(ctx->h[7], &digest[28]);
+#endif /* !UNROLL_LOOPS */
+}
+
+/* SHA-512 functions */
+
+void sha512_transf(sha512_ctx *ctx, const unsigned char *message,
+                   unsigned int block_nb)
+{
+    uint64 w[80];
+    uint64 wv[8];
+    uint64 t1, t2;
+    const unsigned char *sub_block;
+    int i, j;
+
+    for (i = 0; i < (int) block_nb; i++) {
+        sub_block = message + (i << 7);
+
+#ifndef UNROLL_LOOPS
+        for (j = 0; j < 16; j++) {
+            PACK64(&sub_block[j << 3], &w[j]);
+        }
+
+        for (j = 16; j < 80; j++) {
+            SHA512_SCR(j);
+        }
+
+        for (j = 0; j < 8; j++) {
+            wv[j] = ctx->h[j];
+        }
+
+        for (j = 0; j < 80; j++) {
+            t1 = wv[7] + SHA512_F2(wv[4]) + CH(wv[4], wv[5], wv[6])
+                + sha512_k[j] + w[j];
+            t2 = SHA512_F1(wv[0]) + MAJ(wv[0], wv[1], wv[2]);
+            wv[7] = wv[6];
+            wv[6] = wv[5];
+            wv[5] = wv[4];
+            wv[4] = wv[3] + t1;
+            wv[3] = wv[2];
+            wv[2] = wv[1];
+            wv[1] = wv[0];
+            wv[0] = t1 + t2;
+        }
+
+        for (j = 0; j < 8; j++) {
+            ctx->h[j] += wv[j];
+        }
+#else
+        PACK64(&sub_block[  0], &w[ 0]); PACK64(&sub_block[  8], &w[ 1]);
+        PACK64(&sub_block[ 16], &w[ 2]); PACK64(&sub_block[ 24], &w[ 3]);
+        PACK64(&sub_block[ 32], &w[ 4]); PACK64(&sub_block[ 40], &w[ 5]);
+        PACK64(&sub_block[ 48], &w[ 6]); PACK64(&sub_block[ 56], &w[ 7]);
+        PACK64(&sub_block[ 64], &w[ 8]); PACK64(&sub_block[ 72], &w[ 9]);
+        PACK64(&sub_block[ 80], &w[10]); PACK64(&sub_block[ 88], &w[11]);
+        PACK64(&sub_block[ 96], &w[12]); PACK64(&sub_block[104], &w[13]);
+        PACK64(&sub_block[112], &w[14]); PACK64(&sub_block[120], &w[15]);
+
+        SHA512_SCR(16); SHA512_SCR(17); SHA512_SCR(18); SHA512_SCR(19);
+        SHA512_SCR(20); SHA512_SCR(21); SHA512_SCR(22); SHA512_SCR(23);
+        SHA512_SCR(24); SHA512_SCR(25); SHA512_SCR(26); SHA512_SCR(27);
+        SHA512_SCR(28); SHA512_SCR(29); SHA512_SCR(30); SHA512_SCR(31);
+        SHA512_SCR(32); SHA512_SCR(33); SHA512_SCR(34); SHA512_SCR(35);
+        SHA512_SCR(36); SHA512_SCR(37); SHA512_SCR(38); SHA512_SCR(39);
+        SHA512_SCR(40); SHA512_SCR(41); SHA512_SCR(42); SHA512_SCR(43);
+        SHA512_SCR(44); SHA512_SCR(45); SHA512_SCR(46); SHA512_SCR(47);
+        SHA512_SCR(48); SHA512_SCR(49); SHA512_SCR(50); SHA512_SCR(51);
+        SHA512_SCR(52); SHA512_SCR(53); SHA512_SCR(54); SHA512_SCR(55);
+        SHA512_SCR(56); SHA512_SCR(57); SHA512_SCR(58); SHA512_SCR(59);
+        SHA512_SCR(60); SHA512_SCR(61); SHA512_SCR(62); SHA512_SCR(63);
+        SHA512_SCR(64); SHA512_SCR(65); SHA512_SCR(66); SHA512_SCR(67);
+        SHA512_SCR(68); SHA512_SCR(69); SHA512_SCR(70); SHA512_SCR(71);
+        SHA512_SCR(72); SHA512_SCR(73); SHA512_SCR(74); SHA512_SCR(75);
+        SHA512_SCR(76); SHA512_SCR(77); SHA512_SCR(78); SHA512_SCR(79);
+
+        wv[0] = ctx->h[0]; wv[1] = ctx->h[1];
+        wv[2] = ctx->h[2]; wv[3] = ctx->h[3];
+        wv[4] = ctx->h[4]; wv[5] = ctx->h[5];
+        wv[6] = ctx->h[6]; wv[7] = ctx->h[7];
+
+        j = 0;
+
+        do {
+            SHA512_EXP(0,1,2,3,4,5,6,7,j); j++;
+            SHA512_EXP(7,0,1,2,3,4,5,6,j); j++;
+            SHA512_EXP(6,7,0,1,2,3,4,5,j); j++;
+            SHA512_EXP(5,6,7,0,1,2,3,4,j); j++;
+            SHA512_EXP(4,5,6,7,0,1,2,3,j); j++;
+            SHA512_EXP(3,4,5,6,7,0,1,2,j); j++;
+            SHA512_EXP(2,3,4,5,6,7,0,1,j); j++;
+            SHA512_EXP(1,2,3,4,5,6,7,0,j); j++;
+        } while (j < 80);
+
+        ctx->h[0] += wv[0]; ctx->h[1] += wv[1];
+        ctx->h[2] += wv[2]; ctx->h[3] += wv[3];
+        ctx->h[4] += wv[4]; ctx->h[5] += wv[5];
+        ctx->h[6] += wv[6]; ctx->h[7] += wv[7];
+#endif /* !UNROLL_LOOPS */
+    }
+}
+
+void sha512(const unsigned char *message, unsigned int len,
+            unsigned char *digest)
+{
+    sha512_ctx ctx;
+
+    sha512_init(&ctx);
+    sha512_update(&ctx, message, len);
+    sha512_final(&ctx, digest);
+}
+
+void sha512_init(sha512_ctx *ctx)
+{
+#ifndef UNROLL_LOOPS
+    int i;
+    for (i = 0; i < 8; i++) {
+        ctx->h[i] = sha512_h0[i];
+    }
+#else
+    ctx->h[0] = sha512_h0[0]; ctx->h[1] = sha512_h0[1];
+    ctx->h[2] = sha512_h0[2]; ctx->h[3] = sha512_h0[3];
+    ctx->h[4] = sha512_h0[4]; ctx->h[5] = sha512_h0[5];
+    ctx->h[6] = sha512_h0[6]; ctx->h[7] = sha512_h0[7];
+#endif /* !UNROLL_LOOPS */
+
+    ctx->len = 0;
+    ctx->tot_len = 0;
+}
+
+void sha512_update(sha512_ctx *ctx, const unsigned char *message,
+                   unsigned int len)
+{
+    unsigned int block_nb;
+    unsigned int new_len, rem_len, tmp_len;
+    const unsigned char *shifted_message;
+
+    tmp_len = SHA512_BLOCK_SIZE - ctx->len;
+    rem_len = len < tmp_len ? len : tmp_len;
+
+    memcpy(&ctx->block[ctx->len], message, rem_len);
+
+    if (ctx->len + len < SHA512_BLOCK_SIZE) {
+        ctx->len += len;
+        return;
+    }
+
+    new_len = len - rem_len;
+    block_nb = new_len / SHA512_BLOCK_SIZE;
+
+    shifted_message = message + rem_len;
+
+    sha512_transf(ctx, ctx->block, 1);
+    sha512_transf(ctx, shifted_message, block_nb);
+
+    rem_len = new_len % SHA512_BLOCK_SIZE;
+
+    memcpy(ctx->block, &shifted_message[block_nb << 7],
+           rem_len);
+
+    ctx->len = rem_len;
+    ctx->tot_len += (block_nb + 1) << 7;
+}
+
+void sha512_final(sha512_ctx *ctx, unsigned char *digest)
+{
+    unsigned int block_nb;
+    unsigned int pm_len;
+    unsigned int len_b;
+
+#ifndef UNROLL_LOOPS
+    int i;
+#endif
+
+    block_nb = 1 + ((SHA512_BLOCK_SIZE - 17)
+                     < (ctx->len % SHA512_BLOCK_SIZE));
+
+    len_b = (ctx->tot_len + ctx->len) << 3;
+    pm_len = block_nb << 7;
+
+    memset(ctx->block + ctx->len, 0, pm_len - ctx->len);
+    ctx->block[ctx->len] = 0x80;
+    UNPACK32(len_b, ctx->block + pm_len - 4);
+
+    sha512_transf(ctx, ctx->block, block_nb);
+
+#ifndef UNROLL_LOOPS
+    for (i = 0 ; i < 8; i++) {
+        UNPACK64(ctx->h[i], &digest[i << 3]);
+    }
+#else
+    UNPACK64(ctx->h[0], &digest[ 0]);
+    UNPACK64(ctx->h[1], &digest[ 8]);
+    UNPACK64(ctx->h[2], &digest[16]);
+    UNPACK64(ctx->h[3], &digest[24]);
+    UNPACK64(ctx->h[4], &digest[32]);
+    UNPACK64(ctx->h[5], &digest[40]);
+    UNPACK64(ctx->h[6], &digest[48]);
+    UNPACK64(ctx->h[7], &digest[56]);
+#endif /* !UNROLL_LOOPS */
+}
+
+/* SHA-384 functions */
+
+void sha384(const unsigned char *message, unsigned int len,
+            unsigned char *digest)
+{
+    sha384_ctx ctx;
+
+    sha384_init(&ctx);
+    sha384_update(&ctx, message, len);
+    sha384_final(&ctx, digest);
+}
+
+void sha384_init(sha384_ctx *ctx)
+{
+#ifndef UNROLL_LOOPS
+    int i;
+    for (i = 0; i < 8; i++) {
+        ctx->h[i] = sha384_h0[i];
+    }
+#else
+    ctx->h[0] = sha384_h0[0]; ctx->h[1] = sha384_h0[1];
+    ctx->h[2] = sha384_h0[2]; ctx->h[3] = sha384_h0[3];
+    ctx->h[4] = sha384_h0[4]; ctx->h[5] = sha384_h0[5];
+    ctx->h[6] = sha384_h0[6]; ctx->h[7] = sha384_h0[7];
+#endif /* !UNROLL_LOOPS */
+
+    ctx->len = 0;
+    ctx->tot_len = 0;
+}
+
+void sha384_update(sha384_ctx *ctx, const unsigned char *message,
+                   unsigned int len)
+{
+    unsigned int block_nb;
+    unsigned int new_len, rem_len, tmp_len;
+    const unsigned char *shifted_message;
+
+    tmp_len = SHA384_BLOCK_SIZE - ctx->len;
+    rem_len = len < tmp_len ? len : tmp_len;
+
+    memcpy(&ctx->block[ctx->len], message, rem_len);
+
+    if (ctx->len + len < SHA384_BLOCK_SIZE) {
+        ctx->len += len;
+        return;
+    }
+
+    new_len = len - rem_len;
+    block_nb = new_len / SHA384_BLOCK_SIZE;
+
+    shifted_message = message + rem_len;
+
+    sha512_transf(ctx, ctx->block, 1);
+    sha512_transf(ctx, shifted_message, block_nb);
+
+    rem_len = new_len % SHA384_BLOCK_SIZE;
+
+    memcpy(ctx->block, &shifted_message[block_nb << 7],
+           rem_len);
+
+    ctx->len = rem_len;
+    ctx->tot_len += (block_nb + 1) << 7;
+}
+
+void sha384_final(sha384_ctx *ctx, unsigned char *digest)
+{
+    unsigned int block_nb;
+    unsigned int pm_len;
+    unsigned int len_b;
+
+#ifndef UNROLL_LOOPS
+    int i;
+#endif
+
+    block_nb = (1 + ((SHA384_BLOCK_SIZE - 17)
+                     < (ctx->len % SHA384_BLOCK_SIZE)));
+
+    len_b = (ctx->tot_len + ctx->len) << 3;
+    pm_len = block_nb << 7;
+
+    memset(ctx->block + ctx->len, 0, pm_len - ctx->len);
+    ctx->block[ctx->len] = 0x80;
+    UNPACK32(len_b, ctx->block + pm_len - 4);
+
+    sha512_transf(ctx, ctx->block, block_nb);
+
+#ifndef UNROLL_LOOPS
+    for (i = 0 ; i < 6; i++) {
+        UNPACK64(ctx->h[i], &digest[i << 3]);
+    }
+#else
+    UNPACK64(ctx->h[0], &digest[ 0]);
+    UNPACK64(ctx->h[1], &digest[ 8]);
+    UNPACK64(ctx->h[2], &digest[16]);
+    UNPACK64(ctx->h[3], &digest[24]);
+    UNPACK64(ctx->h[4], &digest[32]);
+    UNPACK64(ctx->h[5], &digest[40]);
+#endif /* !UNROLL_LOOPS */
+}
+
+/* SHA-224 functions */
+
+void sha224(const unsigned char *message, unsigned int len,
+            unsigned char *digest)
+{
+    sha224_ctx ctx;
+
+    sha224_init(&ctx);
+    sha224_update(&ctx, message, len);
+    sha224_final(&ctx, digest);
+}
+
+void sha224_init(sha224_ctx *ctx)
+{
+#ifndef UNROLL_LOOPS
+    int i;
+    for (i = 0; i < 8; i++) {
+        ctx->h[i] = sha224_h0[i];
+    }
+#else
+    ctx->h[0] = sha224_h0[0]; ctx->h[1] = sha224_h0[1];
+    ctx->h[2] = sha224_h0[2]; ctx->h[3] = sha224_h0[3];
+    ctx->h[4] = sha224_h0[4]; ctx->h[5] = sha224_h0[5];
+    ctx->h[6] = sha224_h0[6]; ctx->h[7] = sha224_h0[7];
+#endif /* !UNROLL_LOOPS */
+
+    ctx->len = 0;
+    ctx->tot_len = 0;
+}
+
+void sha224_update(sha224_ctx *ctx, const unsigned char *message,
+                   unsigned int len)
+{
+    unsigned int block_nb;
+    unsigned int new_len, rem_len, tmp_len;
+    const unsigned char *shifted_message;
+
+    tmp_len = SHA224_BLOCK_SIZE - ctx->len;
+    rem_len = len < tmp_len ? len : tmp_len;
+
+    memcpy(&ctx->block[ctx->len], message, rem_len);
+
+    if (ctx->len + len < SHA224_BLOCK_SIZE) {
+        ctx->len += len;
+        return;
+    }
+
+    new_len = len - rem_len;
+    block_nb = new_len / SHA224_BLOCK_SIZE;
+
+    shifted_message = message + rem_len;
+
+    sha256_transf(ctx, ctx->block, 1);
+    sha256_transf(ctx, shifted_message, block_nb);
+
+    rem_len = new_len % SHA224_BLOCK_SIZE;
+
+    memcpy(ctx->block, &shifted_message[block_nb << 6],
+           rem_len);
+
+    ctx->len = rem_len;
+    ctx->tot_len += (block_nb + 1) << 6;
+}
+
+void sha224_final(sha224_ctx *ctx, unsigned char *digest)
+{
+    unsigned int block_nb;
+    unsigned int pm_len;
+    unsigned int len_b;
+
+#ifndef UNROLL_LOOPS
+    int i;
+#endif
+
+    block_nb = (1 + ((SHA224_BLOCK_SIZE - 9)
+                     < (ctx->len % SHA224_BLOCK_SIZE)));
+
+    len_b = (ctx->tot_len + ctx->len) << 3;
+    pm_len = block_nb << 6;
+
+    memset(ctx->block + ctx->len, 0, pm_len - ctx->len);
+    ctx->block[ctx->len] = 0x80;
+    UNPACK32(len_b, ctx->block + pm_len - 4);
+
+    sha256_transf(ctx, ctx->block, block_nb);
+
+#ifndef UNROLL_LOOPS
+    for (i = 0 ; i < 7; i++) {
+        UNPACK32(ctx->h[i], &digest[i << 2]);
+    }
+#else
+   UNPACK32(ctx->h[0], &digest[ 0]);
+   UNPACK32(ctx->h[1], &digest[ 4]);
+   UNPACK32(ctx->h[2], &digest[ 8]);
+   UNPACK32(ctx->h[3], &digest[12]);
+   UNPACK32(ctx->h[4], &digest[16]);
+   UNPACK32(ctx->h[5], &digest[20]);
+   UNPACK32(ctx->h[6], &digest[24]);
+#endif /* !UNROLL_LOOPS */
+}
+
+#ifdef TEST_VECTORS
+
+/* FIPS 180-2 Validation tests */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void test(const char *vector, unsigned char *digest,
+          unsigned int digest_size)
+{
+    char output[2 * SHA512_DIGEST_SIZE + 1];
+    int i;
+
+    output[2 * digest_size] = '\0';
+
+    for (i = 0; i < (int) digest_size ; i++) {
+       sprintf(output + 2 * i, "%02x", digest[i]);
+    }
+
+    printf("H: %s\n", output);
+    if (strcmp(vector, output)) {
+        fprintf(stderr, "Test failed.\n");
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main(void)
+{
+    static const char *vectors[4][3] =
+    {   /* SHA-224 */
+        {
+        "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7",
+        "75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525",
+        "20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67",
+        },
+        /* SHA-256 */
+        {
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+        "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+        },
+        /* SHA-384 */
+        {
+        "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed"
+        "8086072ba1e7cc2358baeca134c825a7",
+        "09330c33f71147e83d192fc782cd1b4753111b173b3b05d22fa08086e3b0f712"
+        "fcc7c71a557e2db966c3e9fa91746039",
+        "9d0e1809716474cb086e834e310a4a1ced149e9c00f248527972cec5704c2a5b"
+        "07b8b3dc38ecc4ebae97ddd87f3d8985",
+        },
+        /* SHA-512 */
+        {
+        "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+        "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+        "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018"
+        "501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909",
+        "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973eb"
+        "de0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"
+        }
+    };
+
+    static const char message1[] = "abc";
+    static const char message2a[] = "abcdbcdecdefdefgefghfghighijhi"
+                                    "jkijkljklmklmnlmnomnopnopq";
+    static const char message2b[] = "abcdefghbcdefghicdefghijdefghijkefghij"
+                                    "klfghijklmghijklmnhijklmnoijklmnopjklm"
+                                    "nopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+    unsigned char *message3;
+    unsigned int message3_len = 1000000;
+    unsigned char digest[SHA512_DIGEST_SIZE];
+
+    message3 = malloc(message3_len);
+    if (message3 == NULL) {
+        fprintf(stderr, "Can't allocate memory\n");
+        return -1;
+    }
+    memset(message3, 'a', message3_len);
+
+    printf("SHA-2 FIPS 180-2 Validation tests\n\n");
+    printf("SHA-224 Test vectors\n");
+
+    sha224((const unsigned char *) message1, strlen(message1), digest);
+    test(vectors[0][0], digest, SHA224_DIGEST_SIZE);
+    sha224((const unsigned char *) message2a, strlen(message2a), digest);
+    test(vectors[0][1], digest, SHA224_DIGEST_SIZE);
+    sha224(message3, message3_len, digest);
+    test(vectors[0][2], digest, SHA224_DIGEST_SIZE);
+    printf("\n");
+
+    printf("SHA-256 Test vectors\n");
+
+    sha256((const unsigned char *) message1, strlen(message1), digest);
+    test(vectors[1][0], digest, SHA256_DIGEST_SIZE);
+    sha256((const unsigned char *) message2a, strlen(message2a), digest);
+    test(vectors[1][1], digest, SHA256_DIGEST_SIZE);
+    sha256(message3, message3_len, digest);
+    test(vectors[1][2], digest, SHA256_DIGEST_SIZE);
+    printf("\n");
+
+    printf("SHA-384 Test vectors\n");
+
+    sha384((const unsigned char *) message1, strlen(message1), digest);
+    test(vectors[2][0], digest, SHA384_DIGEST_SIZE);
+    sha384((const unsigned char *)message2b, strlen(message2b), digest);
+    test(vectors[2][1], digest, SHA384_DIGEST_SIZE);
+    sha384(message3, message3_len, digest);
+    test(vectors[2][2], digest, SHA384_DIGEST_SIZE);
+    printf("\n");
+
+    printf("SHA-512 Test vectors\n");
+
+    sha512((const unsigned char *) message1, strlen(message1), digest);
+    test(vectors[3][0], digest, SHA512_DIGEST_SIZE);
+    sha512((const unsigned char *) message2b, strlen(message2b), digest);
+    test(vectors[3][1], digest, SHA512_DIGEST_SIZE);
+    sha512(message3, message3_len, digest);
+    test(vectors[3][2], digest, SHA512_DIGEST_SIZE);
+    printf("\n");
+
+    printf("All tests passed.\n");
+
+    return 0;
+}
+
+#endif /* TEST_VECTORS */
+

--- a/hmac_sha/sha2.h
+++ b/hmac_sha/sha2.h
@@ -1,0 +1,112 @@
+/*
+ * FIPS 180-2 SHA-224/256/384/512 implementation
+ * Last update: 02/02/2007
+ * Issue date:  04/30/2005
+ *
+ * Since this code has been incorporated into a GPLv2 project, it is
+ * distributed under GPLv2 inside mmc-utils.  The original BSD license
+ * that the code was released under is included below for clarity.
+ *
+ * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef SHA2_H
+#define SHA2_H
+
+#define SHA224_DIGEST_SIZE ( 224 / 8)
+#define SHA256_DIGEST_SIZE ( 256 / 8)
+#define SHA384_DIGEST_SIZE ( 384 / 8)
+#define SHA512_DIGEST_SIZE ( 512 / 8)
+
+#define SHA256_BLOCK_SIZE  ( 512 / 8)
+#define SHA512_BLOCK_SIZE  (1024 / 8)
+#define SHA384_BLOCK_SIZE  SHA512_BLOCK_SIZE
+#define SHA224_BLOCK_SIZE  SHA256_BLOCK_SIZE
+
+#ifndef SHA2_TYPES
+#define SHA2_TYPES
+typedef unsigned char uint8;
+typedef unsigned int  uint32;
+typedef unsigned long long uint64;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    unsigned int tot_len;
+    unsigned int len;
+    unsigned char block[2 * SHA256_BLOCK_SIZE];
+    uint32 h[8];
+} sha256_ctx;
+
+typedef struct {
+    unsigned int tot_len;
+    unsigned int len;
+    unsigned char block[2 * SHA512_BLOCK_SIZE];
+    uint64 h[8];
+} sha512_ctx;
+
+typedef sha512_ctx sha384_ctx;
+typedef sha256_ctx sha224_ctx;
+
+void sha224_init(sha224_ctx *ctx);
+void sha224_update(sha224_ctx *ctx, const unsigned char *message,
+                   unsigned int len);
+void sha224_final(sha224_ctx *ctx, unsigned char *digest);
+void sha224(const unsigned char *message, unsigned int len,
+            unsigned char *digest);
+
+void sha256_init(sha256_ctx * ctx);
+void sha256_update(sha256_ctx *ctx, const unsigned char *message,
+                   unsigned int len);
+void sha256_final(sha256_ctx *ctx, unsigned char *digest);
+void sha256(const unsigned char *message, unsigned int len,
+            unsigned char *digest);
+
+void sha384_init(sha384_ctx *ctx);
+void sha384_update(sha384_ctx *ctx, const unsigned char *message,
+                   unsigned int len);
+void sha384_final(sha384_ctx *ctx, unsigned char *digest);
+void sha384(const unsigned char *message, unsigned int len,
+            unsigned char *digest);
+
+void sha512_init(sha512_ctx *ctx);
+void sha512_update(sha512_ctx *ctx, const unsigned char *message,
+                   unsigned int len);
+void sha512_final(sha512_ctx *ctx, unsigned char *digest);
+void sha512(const unsigned char *message, unsigned int len,
+            unsigned char *digest);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !SHA2_H */
+

--- a/options.h
+++ b/options.h
@@ -40,6 +40,11 @@ struct tool_options {
 	int target;
 	int size;
 	char path[PATH_MAX];
+	/* cpy_of_argc and cpy_of_argv are copies of argc and argv of
+	 * main() function
+	 */
+	int cpy_of_argc;
+	char **cpy_of_argv;
 };
 
 int init_options(int opt_cnt, char **opt_arr, struct tool_options *options);

--- a/rpmb.c
+++ b/rpmb.c
@@ -24,7 +24,6 @@
 #include "rpmb.h"
 #include "hmac_sha/hmac_sha2.h"
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define DEBUG 1
 static int read_rpmb_status(struct rpmb_opt *opt);
 static int rpmb_read_counter(struct rpmb_opt *opt);

--- a/rpmb.c
+++ b/rpmb.c
@@ -831,9 +831,9 @@ int do_rpmb(struct tool_options *opt)
 
 static char *help_str =
 	"\nrpmb command usage:\n"
-	"  %s rpmb [status][read-counter][read-data][write-data][write-key]\n"
-	"	[-k </path/to/key][-f output/input file>][-c <block count>]\n"
-	"	[-a <addr>][-p bsg]\n\n"
+	"  %s rpmb [--status][--read_counter][--read_data][--write_data]\n"
+	"	[--write_key] [-k </path/to/key][-f output/input file>]\n"
+	"	[-c <block count>][-a <addr>][-r region][-p bsg]\n\n"
 	"	--status       - Show RPMB LUN status\n"
 	"	--read_data    - Read [-c block count] data from RPMB LUN, and\n"
 	"		         then save to [-f <output file>]\n"

--- a/rpmb.c
+++ b/rpmb.c
@@ -1,0 +1,867 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2017 Micron Technology Inc.
+ *
+ * Author:
+ *	Bean Huo <beanhuo@micron.com>
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "ufs.h"
+#include "options.h"
+#include "scsi_bsg_util.h"
+#include "rpmb.h"
+#include "hmac_sha/hmac_sha2.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#define DEBUG 1
+static int read_rpmb_status(struct rpmb_opt *opt);
+static int rpmb_read_counter(struct rpmb_opt *opt);
+static int rpmb_program_key(struct rpmb_opt *opt);
+static int rpmb_data_read(struct rpmb_opt *opt);
+static int rpmb_data_write(struct rpmb_opt *opt);
+
+static struct ufs_rpmb_type rpmb_op_t[] = {
+	{"status", RPMB_STATUS, read_rpmb_status},
+	{"read_counter", RPMB_READ_COUNTER, rpmb_read_counter},
+	{"write_key", RPMB_PROGRAM_KEY, rpmb_program_key},
+	{"read_data", RPMB_DATA_READ, rpmb_data_read},
+	{"write_data", RPMB_DATA_WRITE, rpmb_data_write}
+};
+
+#define DO_IO(func, fd, buf, nbyte)				\
+	({							\
+		ssize_t ret = 0, r;				\
+		do {						\
+			r = func(fd, buf + ret, nbyte - ret);   \
+			if (r < 0 && errno != EINTR) {		\
+				ret = -1;			\
+				break;				\
+			}  else if (r > 0)			\
+				ret += r;			\
+		} while (r != 0 && (size_t)ret != nbyte);	\
+		ret;						\
+	 })
+
+static void dump_buffer(const __u8 *buf, __u32 len)
+{
+	const __u8 *_buf = buf;
+	__u32 i;
+
+	for (i = 0; i < len; i++) {
+		printf("0x%02x ", _buf[i]);
+		if (!((i + 1) % 16))
+			printf("\n");
+	}
+}
+
+static const char *rpmb_result_str(__u32 result)
+{
+	switch (result) {
+	case NO_ERROR:
+		return "success";
+	case GENERAL_FAILURE:
+	case 0x81:
+		return "General failure";
+	case AUTH_FAILURE:
+		return "Authentication failure";
+	case COUNTER_FAILURE:
+		return "Counter failure";
+	case ADDR_FAILURE:
+	case 0x84:
+		return "Address failure";
+	case WRITE_FAILURE:
+		return "Write failure";
+	case READ_FAILURE:
+	case 0x86:
+		return "Read failure";
+	case KEY_NOT_PROGRAMMED:
+		return "Authentication Key not yet programmed";
+	case WT_PROT_CONFIG_FAILURE:
+		return "SWPC block access failure";
+	case INVALID_WT_PROT_CONFIG_PARA:
+		return "Invalid SWPC parameter";
+	case SEC_WT_PROT_NOT_APPLICABLE:
+		return "Secure Write Protection not applicable";
+	case 0x85:
+		return "Write failure, write counter expired";
+	default:
+		return "Unknown result code";
+	}
+}
+
+static void generate_mac(struct rpmb_mesg_frame *frames_out,
+			 __u8 *mac, __u8 *key, __u32 cnt)
+{
+	hmac_sha256_ctx ctx;
+	__u32 i;
+
+	hmac_sha256_init(&ctx, key, RPMB_MSG_KEY_SIZE);
+	for (i = 0; i < cnt; i++) {
+		hmac_sha256_update(&ctx, frames_out[i].data,
+				   RPMB_INPUT_SIZE_FOR_MAC);
+	}
+	hmac_sha256_final(&ctx, mac, RPMB_MSG_KEY_SIZE);
+}
+
+static int read_key(char *key_path, __u8 *key)
+{
+	struct stat st;
+	int key_size;
+	int key_fd;
+	int rt = ERROR;
+
+	if (key_path[0] != '\0') {
+		if (!strcmp("-", key_path)) {
+			key_fd = STDIN_FILENO;
+		} else {
+			key_fd = open(key_path, O_RDONLY);
+			if (key_fd < 0) {
+				perror("key file open failed");
+				return rt;
+			}
+		}
+	}
+
+	if (key_fd != STDIN_FILENO) {
+		if (fstat(key_fd, &st) < 0)
+			return rt;
+		key_size = st.st_size - 1; /* exclude EOF*/
+		if (key_size <= 0 ||
+		    key_size > RPMB_MSG_KEY_SIZE) {
+			print_error("Invalid UFS RPMB key/MAC size %d",
+				    key_size);
+			return rt;
+		}
+	}
+
+	rt = DO_IO(read, key_fd, key, RPMB_MSG_KEY_SIZE);
+	if (rt < 0) {
+		print_error("Read the key failed");
+		return rt;
+	} else if (rt != RPMB_MSG_KEY_SIZE) {
+		print_error("Read %d bytes, auth key must be %lu bytes length",
+			    rt,
+			    RPMB_MSG_KEY_SIZE);
+		return rt;
+	}
+
+	return OK;
+}
+
+static int execute_read_write(int bsg_fd, struct rpmb_mesg_frame *msg_in,
+			      struct rpmb_mesg_frame *msg_out, __u32 cnt,
+			      __u8 region, __u16 req_type)
+{
+	int rt = ERROR;
+	__u16 expected_rsp;
+	struct rpmb_mesg_frame rpmb_status = {0};
+	__u16 sec_spec = (region << 8) | UFS_SECURITY_PROTOCOL_SPECIFIC;
+
+	switch (req_type) {
+	case RPMB_KEY_WRITE_REQ:
+	case RPMB_WRITE_REQ:
+		expected_rsp = (req_type == RPMB_KEY_WRITE_REQ) ?
+			RPMB_KEY_PROG_RSP : RPMB_WRITE_RSP;
+		/*
+		 * Step 1: Programming request
+		 */
+		rt = submit_sec_cdb(bsg_fd,
+				    sec_spec,
+				    UFS_SECURITY_PROTOCOL,
+				    (char *)msg_in,
+				    (cnt * RPMB_MSG_SIZE),
+				    1);
+		if (rt < 0) {
+			print_error("Failed to send programming request");
+			goto out;
+		}
+		/*
+		 * Step 2: Result read request
+		 */
+		rpmb_status.req_resp = htobe16(RPMB_RESULT_RD_REQ);
+		rt = submit_sec_cdb(bsg_fd,
+				    sec_spec,
+				    UFS_SECURITY_PROTOCOL,
+				    (char *)&rpmb_status,
+				    RPMB_MSG_SIZE, 1);
+		if (rt < 0) {
+			print_error("Failed to send result read request");
+			goto out;
+		}
+		/*
+		 * Step 3: Result read response
+		 */
+		rt = submit_sec_cdb(bsg_fd,
+				    sec_spec,
+				    UFS_SECURITY_PROTOCOL, (char *)msg_out,
+				    RPMB_MSG_SIZE, 0);
+		if (rt < 0) {
+			print_error("Failed to read response");
+			print_error("rt:%d, result:0x%x, req_resp: 0x%x",
+				    rt,
+				    be16toh(msg_out->result),
+				    be16toh(msg_out->req_resp));
+			goto out;
+		}
+		break;
+	case RPMB_WC_READ_REQ:
+	case RPMB_READ_REQ:
+		expected_rsp = (req_type == RPMB_READ_REQ) ?
+			RPMB_READ_RSP : RPMB_WC_READ_RSP;
+		/*
+		 * Step 1: Send read request
+		 */
+		rt = submit_sec_cdb(bsg_fd,
+				    sec_spec,
+				    UFS_SECURITY_PROTOCOL, (char *)msg_in,
+				    RPMB_MSG_SIZE, 1);
+		if (rt < 0) {
+			print_error("Failed to send read request");
+			goto out;
+		}
+		/*
+		 * Step 2: Read response
+		 */
+		rt = submit_sec_cdb(bsg_fd,
+				    sec_spec,
+				    UFS_SECURITY_PROTOCOL, (char *)msg_out,
+				    (cnt * RPMB_MSG_SIZE), 0);
+		if (rt < 0) {
+			print_error("Failed to read response");
+			goto out;
+		}
+		break;
+	default:
+		print_error("Unkonw RPMB request type");
+		rt = -EINVAL;
+		goto out;
+	}
+	if (be16toh(msg_out[cnt - 1].result) != 0x0000) {
+		print_error("RPMB response got error result:%s",
+			    rpmb_result_str(be16toh(msg_out[cnt - 1].result)));
+		rt = ERROR;
+		goto out;
+	}
+	if (be16toh(msg_out->req_resp) != expected_rsp) {
+		print_error("RPMB response mismatch");
+		printf("Received: 0x%x, expected 0x%x",
+		       expected_rsp,
+		       be16toh(msg_out->req_resp));
+		rt = ERROR;
+	}
+out:
+	return rt;
+}
+
+static int rpmb_program_key(struct rpmb_opt *opt)
+{
+	int rt = ERROR;
+	int bsg_fd = INVALID;
+	struct rpmb_mesg_frame rpmb_msg_in = {0};
+	struct rpmb_mesg_frame rpmb_msg_out = {0};
+	__u8 region;
+
+	bsg_fd = open(opt->bsg_path, O_RDWR);
+	if (bsg_fd < 0) {
+		print_error("Failed to open RPMB bsg device");
+		return rt;
+	}
+	/*
+	 * Read key
+	 */
+	rt = read_key(opt->key_path, rpmb_msg_in.key_mac);
+	if (rt) {
+		print_error("Failed to read key");
+		goto out;
+	}
+	/*
+	 * Auth Key Programming
+	 */
+	region = opt->region;
+	rpmb_msg_in.req_resp = htobe16(RPMB_KEY_WRITE_REQ);
+	rt = execute_read_write(bsg_fd, &rpmb_msg_in, &rpmb_msg_out, 1,
+				region, RPMB_KEY_WRITE_REQ);
+	if (rt < 0)
+		print_error("execute_read_write() failed while writing key");
+out:
+	close(bsg_fd);
+	return rt;
+}
+
+static int read_rpmb_status(struct rpmb_opt *opt)
+{
+	int rt = ERROR;
+	int bsg_fd = INVALID;
+	__u8 buf[18] = {0};
+
+	bsg_fd = open(opt->bsg_path, O_RDWR);
+	if (bsg_fd < 0) {
+		print_error("Failed to open RPMB bsg device");
+		return rt;
+	}
+
+	rt = ufs_request_sense(bsg_fd, buf, 18);
+	if (rt < 0) {
+		print_error("ufs_request_sense() ret %d", rt);
+	} else {
+		printf("RPMB LUN sense data:\n");
+		dump_buffer(buf, 18);
+	}
+
+	close(bsg_fd);
+	return 0;
+}
+
+static int verify_data_with_local_key(struct rpmb_mesg_frame *frames_out,
+				      __u8 *key, __u32 cnt)
+{
+	int rt = ERROR;
+	__u8 mac[RPMB_MSG_KEY_SIZE];
+
+	generate_mac(frames_out, mac, key, cnt);
+
+	if (memcmp(mac, frames_out[cnt - 1].key_mac, RPMB_MSG_KEY_SIZE)) {
+		print_error("RPMB MAC mismatch");
+		printf("Recived MAC:\n");
+		dump_buffer(frames_out[cnt - 1].key_mac, RPMB_MSG_KEY_SIZE);
+		printf("Expected MAC:\n");
+		dump_buffer(mac, RPMB_MSG_KEY_SIZE);
+	} else {
+		rt = OK;
+	}
+
+	return rt;
+}
+
+static int do_read_counter(int bsg_fd, char *key_path, __u8 region,
+			   __u32 *counter, _Bool need_check)
+{
+	int rt = ERROR;
+	__u8 key[RPMB_MSG_KEY_SIZE];
+	struct rpmb_mesg_frame rpmb_msg_in = {0};
+	struct rpmb_mesg_frame rpmb_msg_out = {0};
+
+	rpmb_msg_in.req_resp = htobe16(RPMB_WC_READ_REQ);
+	rt = execute_read_write(bsg_fd, &rpmb_msg_in,
+				&rpmb_msg_out, 1,
+				region, RPMB_WC_READ_REQ);
+	if (rt < 0) {
+		print_error("execute_read_write() failed while reading WC");
+		goto out;
+	}
+
+	if (need_check && (key_path[0] != '\0')) {
+		rt = read_key(key_path, key);
+		if (rt) {
+			print_error("Failed to read key");
+			goto out;
+		}
+		if (memcmp(&rpmb_msg_in.nonce,
+			   &rpmb_msg_out.nonce,
+			   RPMB_MSG_NONCE_SIZE)) {
+			print_error("RPMB NONCE mismatch");
+			goto out;
+		}
+		rt = verify_data_with_local_key(&rpmb_msg_out, key, 1);
+		if (rt) {
+			print_error("MAC verification failed");
+			goto out;
+		}
+	}
+
+	*counter = be32toh(rpmb_msg_out.write_counter);
+out:
+	return rt;
+}
+
+static int rpmb_read_counter(struct rpmb_opt *opt)
+{
+	int rt = ERROR;
+	int bsg_fd = INVALID;
+	__u32 counter;
+
+	bsg_fd = open(opt->bsg_path, O_RDWR);
+	if (bsg_fd < 0) {
+		print_error("Failed to open bsg device");
+		return rt;
+	}
+
+	rt = do_read_counter(bsg_fd, opt->key_path, opt->region, &counter, 1);
+	if (rt < 0)
+		print_error("Read RPMB Region_%d write_counter failed",
+				opt->region);
+	else
+		printf("\n\tRPMB Region_%d wirite counter: 0x%02x\n\n",
+				opt->region, counter);
+
+	close(bsg_fd);
+	return rt;
+}
+
+static int rpmb_data_read(struct rpmb_opt *opt)
+{
+	int rt = ERROR;
+	int bsg_fd = INVALID, out_fd = INVALID;
+	struct rpmb_mesg_frame rpmb_msg_in = {0};
+	struct rpmb_mesg_frame *rpmb_msg_out = NULL;
+	__u8 key[RPMB_MSG_KEY_SIZE];
+	__u16 blk_cnt, addr;
+	__u8 region;
+
+	if (opt->block_counts == INVALID || opt->block_counts == 0) {
+		print_error("block_counts specified is not proper");
+		return rt;
+	}
+
+	addr = opt->addr;
+	blk_cnt = opt->block_counts;
+	region = opt->region;
+
+	rpmb_msg_out =
+		(struct rpmb_mesg_frame *)calloc(blk_cnt, RPMB_MSG_SIZE);
+	if (!rpmb_msg_out) {
+		print_error("Failed to allocate rpmb_mesg_frame");
+		rt = -ENOMEM;
+		return rt;
+	}
+
+	bsg_fd = open(opt->bsg_path, O_RDWR);
+	if (bsg_fd < 0) {
+		print_error("Failed to open RPMB bsg device");
+		goto out;
+	}
+
+	rpmb_msg_in.req_resp = htobe16(RPMB_READ_REQ);
+	rpmb_msg_in.addr = htobe16(addr);
+	rpmb_msg_in.block_count = htobe16(blk_cnt);
+	rt = execute_read_write(bsg_fd, &rpmb_msg_in, rpmb_msg_out,
+				blk_cnt, region, RPMB_READ_REQ);
+	if (rt < 0) {
+		print_error("execute_read_write() failed while reading data");
+		goto out;
+	}
+
+	/*
+	 * Read key, and verify data
+	 */
+	if (opt->key_path[0] != '\0') {
+		rt = read_key(opt->key_path, key);
+		if (rt) {
+			print_error("Read key/MAC failed");
+			goto out;
+		}
+		if (memcmp(&rpmb_msg_in.nonce, &rpmb_msg_out[blk_cnt - 1].nonce,
+			   RPMB_MSG_NONCE_SIZE)) {
+			print_error("RPMB NONCE mismatch");
+			goto out;
+		}
+		rt = verify_data_with_local_key(rpmb_msg_out, key, blk_cnt);
+		if (rt) {
+			print_error("MAC verification failed");
+			goto out;
+		}
+	}
+	/*
+	 * Output data
+	 */
+	if (!strcmp(opt->io_file, "-")) {
+		out_fd = STDOUT_FILENO;
+	} else {
+		out_fd = open(opt->io_file,
+			      O_WRONLY | O_CREAT | O_APPEND, 0600);
+		if (out_fd < 0) {
+			print_error("can't open output file");
+			goto out;
+		}
+	}
+	int i;
+
+	for (i = 0; i < blk_cnt; i++) {
+		rt = DO_IO(write, out_fd, rpmb_msg_out[i].data,
+			   RPMB_MSG_DATA_SIZE);
+		if (rt < 0) {
+			print_error("failed to output data");
+			goto out;
+		}
+#ifdef DEBUG
+		printf("\nData read from RPMB Region_%d,0x%08x:\n",
+				region, (addr + i * RPMB_MSG_DATA_SIZE));
+		dump_buffer(rpmb_msg_out[i].data, RPMB_MSG_DATA_SIZE);
+#endif
+	}
+
+out:
+	free(rpmb_msg_out);
+	close(bsg_fd);
+	if (out_fd != STDOUT_FILENO)
+		close(out_fd);
+
+	return rt;
+}
+
+static int rpmb_data_write(struct rpmb_opt *opt)
+{
+	int rt = ERROR;
+	int bsg_fd = INVALID, file_fd = INVALID;
+	__u16 blk_cnt, addr;
+	__u32 write_counter;
+	struct rpmb_mesg_frame *rpmb_msg_in = NULL;
+	struct rpmb_mesg_frame rpmb_msg_out = {0};
+	__u8 key[RPMB_MSG_KEY_SIZE];
+	__u32 i;
+	__u8 region;
+
+	if (opt->addr == INVALID) {
+		print_error("Accessed address is invalid");
+		return rt;
+	}
+	if (opt->block_counts == INVALID || opt->block_counts == 0) {
+		print_error("block_counts specified is not proper");
+		return rt;
+	}
+	if (opt->io_file[0] == '\0') {
+		print_error("didn't specify input");
+		return rt;
+	}
+
+	blk_cnt = opt->block_counts;
+	addr = opt->addr;
+	region = opt->region;
+
+	bsg_fd = open(opt->bsg_path, O_RDWR);
+	if (bsg_fd < 0) {
+		print_error("Failed to open RPMB device");
+		return rt;
+	}
+	/*
+	 * Read Key
+	 */
+	rt = read_key(opt->key_path, key);
+	if (rt) {
+		print_error("Failed to read key");
+		close(bsg_fd);
+		return rt;
+	}
+
+	file_fd = open(opt->io_file, O_RDONLY);
+	if (bsg_fd < 0) {
+		print_error("Failed to open input file");
+		close(bsg_fd);
+		return rt;
+	}
+
+	rpmb_msg_in = (struct rpmb_mesg_frame *)calloc(blk_cnt, RPMB_MSG_SIZE);
+	if (!rpmb_msg_in) {
+		print_error("Failed to allocate rpmb_mesg_frame");
+		rt = -ENOMEM;
+		goto out;
+	}
+	memset(rpmb_msg_in, 0, blk_cnt * RPMB_MSG_SIZE);
+
+	rt = do_read_counter(bsg_fd, opt->key_path, opt->region,
+			(__u32 *)&write_counter, 1);
+	if (rt < 0) {
+		print_error("Failed to read RPMB write_counter");
+		goto out;
+	}
+
+	for (i = 0; i < blk_cnt; i++) {
+		rpmb_msg_in[i].write_counter = htobe32(write_counter);
+		rpmb_msg_in[i].addr = htobe16(addr);
+		rpmb_msg_in[i].block_count = htobe16(blk_cnt);
+		rpmb_msg_in[i].req_resp = htobe16(RPMB_WRITE_REQ);
+
+		rt  = DO_IO(read, file_fd, rpmb_msg_in[i].data,
+			    RPMB_MSG_DATA_SIZE);
+		if (rt < 0) {
+			print_error("Failed to read data from input file");
+			goto out;
+		}
+	}
+
+	generate_mac(rpmb_msg_in, rpmb_msg_in[blk_cnt - 1].key_mac,
+		     key, blk_cnt);
+
+	rt = execute_read_write(bsg_fd, rpmb_msg_in, &rpmb_msg_out, blk_cnt,
+				region, RPMB_WRITE_REQ);
+	if (rt < 0)
+		print_error("execute_read_write() failed while writing data");
+
+out:
+	close(bsg_fd);
+	close(file_fd);
+	free(rpmb_msg_in);
+	return rt;
+}
+
+static int check_op_type(const char *name, struct rpmb_opt *op,
+		int (**func)(struct rpmb_opt *))
+{
+	int rt = INVALID;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(rpmb_op_t); i++) {
+		if (!strcmp(name, rpmb_op_t[i].name)) {
+			if (op->type == INVALID) {
+				op->type = rpmb_op_t[i].type;
+				*func = rpmb_op_t[i].func;
+				rt = OK;
+			} else {
+				print_error("Duplicate rpmb operation type");
+			}
+			break;
+		}
+	}
+
+	return rt;
+}
+
+int check_path(char *dest, char *path)
+{
+	if (dest[0] != '\0') {
+		print_error("Duplicate path");
+		goto out;
+	}
+
+	if (!optarg || optarg[0] == 0) {
+		print_error("Path missed");
+		goto out;
+	}
+
+	strcpy(dest, path);
+	return OK;
+out:
+	return INVALID;
+}
+
+static int check_rpmb_region(struct rpmb_opt *op)
+{
+	int rt = OK;
+
+	if (strstr(optarg, "0x") || strstr(optarg, "0X"))
+		op->region = (int)strtol(optarg, NULL, 0);
+	else
+		op->region = atoi(optarg);
+
+	if (op->region > 3 || op->region < 0) {
+		print_error("Invalid argument for RPMB region");
+		rt = INVALID;
+	}
+
+	return rt;
+}
+
+static int check_block_count(struct rpmb_opt *op)
+{
+	int rt = OK;
+
+	if (strstr(optarg, "0x") || strstr(optarg, "0X"))
+		op->block_counts = (int)strtol(optarg, NULL, 0);
+	else
+		op->block_counts = atoi(optarg);
+
+	if (!optarg ||
+	    (op->block_counts == 0 && strcmp(optarg, "0")) ||
+	    op->block_counts < 0) {
+		print_error("Invalid argument for block count");
+		rt = INVALID;
+	}
+
+	return rt;
+}
+
+static int check_address(struct rpmb_opt *op)
+{
+	int rt = OK;
+
+	if (strstr(optarg, "0x") || strstr(optarg, "0X"))
+		op->addr = (int)strtol(optarg, NULL, 0);
+	else
+		op->addr = atoi(optarg);
+
+	return rt;
+}
+
+static int rpmb_parser(int argc, char **argv, struct rpmb_opt *op,
+		int (**func)(struct rpmb_opt *))
+{
+	int rt = -EINVAL;
+	int curr_opt = 0;
+	int index = 0;
+
+	static struct option long_opts[] = {
+		{"read_counter", no_argument, NULL, 0}, /* read counter */
+		{"status", no_argument, NULL, 0}, /* status */
+		{"read_data", no_argument, NULL, 0}, /* read data */
+		{"write_data", no_argument, NULL, 0}, /* write data */
+		{"write_key", no_argument, NULL, 0}, /* write key */
+		{NULL, 0, NULL, 0}
+	};
+	static char *short_opts = "k:p:f:c:a:r:";
+
+	while (-1 !=
+	      (curr_opt = getopt_long(argc, argv, short_opts,
+				      long_opts, &index))) {
+		switch (curr_opt) {
+		case 0:
+			rt = check_op_type(long_opts[index].name, op, func);
+			break;
+		case 'k':
+			rt = check_path(op->key_path, optarg);
+			break;
+		case 'p':
+			rt = check_path(op->bsg_path, optarg);
+			break;
+		case 'f':
+			rt = check_path(op->io_file, optarg);
+			break;
+		case 'c':
+			rt = check_block_count(op);
+			break;
+		case 'a':
+			rt = check_address(op);
+			break;
+		case 'r':
+			rt = check_rpmb_region(op);
+			break;
+		default:
+			rt = -EINVAL;
+			break;
+		}
+		if (rt)
+			break;
+	}
+
+	return rt;
+}
+
+static int check_rpmb_opt(struct rpmb_opt *opt)
+{
+	int rt = OK;
+	enum rpmb_type type = opt->type;
+
+	if (type == INVALID) {
+		print_error("Unknown operation type");
+		exit(1);
+	}
+
+	if (opt->bsg_path[0] == '\0') {
+		print_error("RPMB bsg device path is missing");
+		rt = ERROR;
+	}
+
+	if (type == RPMB_READ_COUNTER || type == RPMB_PROGRAM_KEY ||
+		type == RPMB_DATA_READ || type == RPMB_DATA_WRITE){
+		if (opt->region == INVALID) {
+			print_error("RPMB region number is missing");
+			rt = ERROR;
+		}
+	}
+
+	if (type == RPMB_PROGRAM_KEY || type == RPMB_DATA_WRITE) {
+		if (opt->key_path[0] == '\0') {
+			print_error("RPMB region %d key path is missing",
+					opt->region);
+			rt = ERROR;
+		}
+	}
+
+	if (type == RPMB_DATA_READ || type == RPMB_DATA_WRITE) {
+		if (opt->io_file[0] == '\0') {
+			print_error("input/output path is missing");
+			rt = ERROR;
+		}
+		if (opt->block_counts == INVALID) {
+			print_error("block count is missing");
+			rt = ERROR;
+		}
+		if (opt->addr == INVALID) {
+			print_error("Address is missing");
+			rt = ERROR;
+		}
+	}
+
+	return rt;
+}
+
+static void init_rpmb_opt(struct rpmb_opt *opt)
+{
+	opt->key_path[0] = '\0';
+	opt->bsg_path[0] = '\0';
+	opt->io_file[0] = '\0';
+	opt->addr = INVALID;
+	opt->block_counts = INVALID;
+	opt->region = INVALID;
+	opt->type = INVALID;
+}
+
+int do_rpmb(struct tool_options *opt)
+{
+	int rt = OK;
+	struct rpmb_opt op;
+	int (*func)(struct rpmb_opt *opt) = NULL;
+
+	init_rpmb_opt(&op);
+
+	rt = rpmb_parser(opt->cpy_of_argc, opt->cpy_of_argv, &op, &func);
+	if (rt != OK) {
+		print_error("Failed to parse rpmb command paramters");
+		rpmb_help(opt->cpy_of_argv[0]);
+		return rt;
+	}
+
+	rt = check_rpmb_opt(&op);
+	if (!rt)
+		rt = func(&op);
+
+	return rt;
+}
+
+static char *help_str =
+	"\nrpmb command usage:\n"
+	"  %s rpmb [status][read-counter][read-data][write-data][write-key]\n"
+	"	[-k </path/to/key][-f output/input file>][-c <block count>]\n"
+	"	[-a <addr>][-p bsg]\n\n"
+	"	--status       - Show RPMB LUN status\n"
+	"	--read_data    - Read [-c block count] data from RPMB LUN, and\n"
+	"		         then save to [-f <output file>]\n"
+	"	--write_data   - Write [-c block count] data from [-f input file]\n"
+	"		         to RPMB LUN at address [-a <address>]\n"
+	"	--write_key    - Program key stored in [-k /path/to/key]\n"
+	"	--read_counter - Read write-counter from RPMB LUN to stdout\n"
+	"	-k specify the key file\n"
+	"	-f specify the output or input file\n"
+	"	-c specify Num. of 256 Bytes blocks will be read or wrote\n"
+	"	-a specify the address to read/write\n"
+	"	-r specify which RPMB region to access\n"
+	"	-p Path to RPMB bsg device\n\n"
+	"  Note :\n"
+	"	1. As for the format of the address inputted, hex number\n"
+	"	   should be prefixed by 0x/0X\n"
+	"	2. If you want to input key from standard input terminal,\n"
+	"	   and output the data to standard output terminal, please\n"
+	"	   use - as parameter of -k and -f when read data\n"
+	"  Eg :\n"
+	"	1. Authentication Key Programming:\n"
+	"	   %s rpmb --write_key -k /path/to/key -r 0 -p /path/to/rpmb/bsg\n"
+	"	2. Read RPMB write counter, don't need verification with key:\n"
+	"	   %s rpmb --read_counter -r 0 -p /path/to/rpmb/bsg\n"
+	"	3. Read RPMB write counter, need verification with key. The key\n"
+	"	   is read through standard input terminal:\n"
+	"	   %s rpmb --read_counter -k - -r 0 -p /path/to/rpmb/bsg\n\n";
+void rpmb_help(char *tool_name)
+{
+	printf(help_str, tool_name, tool_name, tool_name, tool_name);
+}

--- a/rpmb.h
+++ b/rpmb.h
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (C) 2017 Micron Technology Inc.
+ *
+ * Author:
+ *	Bean Huo <beanhuo@micron.com>
+ *
+ */
+#ifndef RPMB_H_
+#define RPMB_H_
+
+#define RPMB_MSG_STUFF_BYTES	196
+#define RPMB_MSG_KEY_SIZE	32
+#define RPMB_MSG_DATA_SIZE	256
+#define RPMB_MSG_NONCE_SIZE	16
+#define RPMB_MSG_WC_SIZE	4
+#define RPMB_MSG_ADDR_SIZE	2
+#define RPMB_MSG_BLK_CNT_SIZE	2
+#define RPMB_MSG_RESULT_SIZE	2
+#define RPMB_MSG_REQ_RESP_SIZE	2
+#define RPMB_MSG_SIZE 512
+#define RPMB_INPUT_SIZE_FOR_MAC 284 /*Input to the MAC calculation is
+				      the concatenation of the fields
+				      in the RPMB Message Data Frames
+				      from byte 228 to byte 511 (stuff_bytes
+				      bytes and the MAC are excluded)
+				      */
+/*
+ * Request Message Types
+ */
+#define RPMB_KEY_WRITE_REQ	0x0001 /* Program RPMB Authentication Key */
+#define RPMB_WC_READ_REQ	0x0002 /* Read RPMB write counter */
+#define RPMB_WRITE_REQ		0x0003 /* Write data to RPMB partition */
+#define RPMB_READ_REQ		0x0004 /* Read data from RPMB partition */
+#define RPMB_RESULT_RD_REQ	0x0005 /* Read result request  (Internal) */
+/*
+ * Response Message Types
+ */
+#define RPMB_KEY_PROG_RSP	0x0100 /* Key Prog. Response */
+#define RPMB_WC_READ_RSP	0x0200 /* Read Write_Counter value response*/
+#define RPMB_WRITE_RSP		0x0300 /* Write response */
+#define RPMB_READ_RSP		0x0400 /* Read Response */
+
+/*
+ * struct rpmb_mesg__frame - RPMB message data frame
+ */
+struct rpmb_mesg_frame {
+	__u8 stuff_bytes[RPMB_MSG_STUFF_BYTES];
+	__u8 key_mac[RPMB_MSG_KEY_SIZE];
+	__u8 data[RPMB_MSG_DATA_SIZE];
+	__u8 nonce[RPMB_MSG_NONCE_SIZE];
+	__u32 write_counter;
+	__u16 addr;
+	__u16 block_count;
+	__u16 result;
+	__u16 req_resp;
+} __packed;
+
+enum rpmb_type {
+	RPMB_STATUS = 1,
+	RPMB_DATA_READ,
+	RPMB_DATA_WRITE,
+	RPMB_PROGRAM_KEY,
+	RPMB_READ_COUNTER
+};
+
+/*
+ * Result code definition
+ */
+enum rpmb_op_result {
+	NO_ERROR,
+	GENERAL_FAILURE,
+	AUTH_FAILURE,
+	COUNTER_FAILURE,
+	ADDR_FAILURE,
+	WRITE_FAILURE,
+	READ_FAILURE,
+	KEY_NOT_PROGRAMMED,
+	WT_PROT_CONFIG_FAILURE,
+	INVALID_WT_PROT_CONFIG_PARA,
+	SEC_WT_PROT_NOT_APPLICABLE
+};
+
+struct rpmb_opt {
+	int type;
+	char bsg_path[1024];
+	char key_path[1024];
+	char io_file[1024];
+	int block_counts;
+	int addr;
+	int region;
+};
+
+struct ufs_rpmb_type {
+	const char *name;
+	int type;
+	int (*func)(struct rpmb_opt *opt);
+};
+
+void rpmb_help(char *tool_name);
+int do_rpmb(struct tool_options *opt);
+#endif /*RPMB_H_*/

--- a/scsi_bsg_util.h
+++ b/scsi_bsg_util.h
@@ -23,9 +23,14 @@
 #define SENSE_BUFF_LEN	(32)
 #define WRITE_BUF_CMDLEN 10
 #define READ_BUF_CMDLEN 10
+#define SEC_PROTOCOL_CMDLEN 12
 #define WRITE_BUFFER_CMD 0x3B
 #define READ_BUFFER_CMD 0x3c
-
+#define REQUEST_SENSE 0x03
+#define SECURITY_PROTOCOL_OUT 0xB5
+#define SECURITY_PROTOCOL_IN  0xA2
+#define UFS_SECURITY_PROTOCOL 0xEC
+#define UFS_SECURITY_PROTOCOL_SPECIFIC 0x0001
 /**
  * struct utp_upiu_header - UPIU header structure
  * @dword_0: UPIU header DW-0
@@ -126,5 +131,8 @@ int read_buffer(int fd, __u8 *buf, uint8_t mode, __u8 buf_id,
 		__u32 buf_offset, int byte_count);
 int write_buffer(int fd, __u8 *buf, __u8 mode, __u8 buf_id, __u32 buf_offset,
 		int byte_count);
+int submit_sec_cdb(int fd, __u16 spsp, __u8 secp, char *buf,
+		int len, _Bool send);
+int ufs_request_sense(int unit_fd, __u8 *buf, int bytes);
 #endif /* BSG_UTIL_H_ */
 

--- a/ufs.h
+++ b/ufs.h
@@ -8,6 +8,7 @@
 #include "ioctl.h"
 #include "scsi_bsg_util.h"
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define BLOCK_SIZE 512
 #define MAX_UFS_COMMAND_LEN 16
 

--- a/ufs.h
+++ b/ufs.h
@@ -135,7 +135,8 @@ enum ufs_cong_type {
 	FLAG_TYPE,
 	ERR_HIST_TYPE,
 	UIC_TYPE,
-	FFU_TYPE
+	FFU_TYPE,
+	RPMB_TYPE
 };
 
 /* UTP UPIU Transaction Codes Initiator to Target */

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -19,6 +19,7 @@
 #include "ufs_err_hist.h"
 #include "unipro.h"
 #include "ufs_ffu.h"
+#include "rpmb.h"
 
 #define STR_BUF_LEN 33
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -1173,6 +1174,9 @@ void print_command_help(char *prgname, int config_type)
 		break;
 	case UIC_TYPE:
 		unipro_help(prgname);
+		break;
+	case RPMB_TYPE:
+		rpmb_help(prgname);
 		break;
 	default:
 		print_error("Unsupported cmd type");

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -22,7 +22,6 @@
 #include "rpmb.h"
 
 #define STR_BUF_LEN 33
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define ATTR_RSRV() "Reserved", BYTE, ACC_INVALID, MODE_INVALID, LEVEL_INVALID
 
 struct desc_field_offset device_desc_field_name[] = {


### PR DESCRIPTION
This patch is to add support for RPMB unit access. If we enable general
BSG module, one character device of RPMB will be create in /dev/bsg folder,
for example: /dev/bsg/0:0:0:49476. This application is just using this
device node to access UFS RPMB unit.