### PR TITLE
ufs-utils: include <endian.h> for endian-related functions

### DIFF
--- a/scsi_bsg_util.c
+++ b/scsi_bsg_util.c
@@ -7,6 +7,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <endian.h>
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <endian.h>
 #include <errno.h>
 #include <stdint.h>
 

--- a/ufs_err_hist.c
+++ b/ufs_err_hist.c
@@ -14,6 +14,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <endian.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/ufs_ffu.c
+++ b/ufs_ffu.c
@@ -7,6 +7,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <endian.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/ufs_hmr.c
+++ b/ufs_hmr.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <endian.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>

--- a/ufs_rpmb.c
+++ b/ufs_rpmb.c
@@ -7,6 +7,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <endian.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
Add <endian.h> header for endian-related functions to fix
build errors by compiler aarch64-linux-android29-clang.

Signed-off-by: Stanley Chu <stanley.chu@mediatek.com>