### PR TITLE
Use asm/type.h for kernel types

### DIFF
--- a/ufs.h
+++ b/ufs.h
@@ -4,7 +4,6 @@
 
 #ifndef UFS_H_
 #define UFS_H_
-#include <asm-generic/int-ll64.h>
 #include "ioctl.h"
 #include "scsi_bsg_util.h"
 

--- a/ufs_cmds.h
+++ b/ufs_cmds.h
@@ -5,7 +5,7 @@
 #define UFS_CMNDS_H_
 
 #include "options.h"
-#include <asm-generic/int-ll64.h>
+#include <asm/types.h>
 
 
 enum field_width {

--- a/ufs_ffu.c
+++ b/ufs_ffu.c
@@ -12,7 +12,6 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <errno.h>
-#include <asm-generic/int-ll64.h>
 
 #include "ufs.h"
 #include "ufs_cmds.h"


### PR DESCRIPTION
This ensures that right headers for types is included otherwise it can
conflict for some platforms e.g. ppc64 where it includes the underlying
files conditionally

asm/types.h is

if !defined(__SANE_USERSPACE_TYPES__) && defined(__powerpc64__) && !defined(__KERNEL__)
 include <asm-generic/int-l64.h>
else
 include <asm-generic/int-ll64.h>
endif

Signed-off-by: Khem Raj <raj.khem@gmail.com>