### PR TITLE
Give option to read/write reserved flags & attribute

### DIFF
--- a/options.c
+++ b/options.c
@@ -260,16 +260,7 @@ static int verify_and_set_idn(struct tool_options *options)
 		}
 		break;
 	case ATTR_TYPE:
-		if (idn >= QUERY_ATTR_IDN_MAX) {
-			print_error("Invalid attr idn %d", idn);
-			goto out;
-		}
-		break;
 	case FLAG_TYPE:
-		if (idn > QUERY_FLAG_IDN_MAX) {
-			print_error("Invalid flag idn %d", idn);
-			goto out;
-		}
 		break;
 	case UIC_TYPE:
 		if (idn >= MAX_UNIPRO_IDN) {

--- a/options.h
+++ b/options.h
@@ -20,7 +20,6 @@
 #define TOGGLE_FLAG 4
 #define READ_ALL 5
 
-
 #define ALIGNMENT_CHUNK_SIZE 4096
 
 struct tool_options {

--- a/ufs.c
+++ b/ufs.c
@@ -21,7 +21,7 @@
 #include "ufs_rpmb.h"
 #include "ufs_hmr.h"
 
-#define UFS_BSG_UTIL_VERSION	"1.9"
+#define UFS_BSG_UTIL_VERSION	"1.10"
 typedef int (*command_function)(struct tool_options *opt);
 
 struct tool_command {


### PR DESCRIPTION
Some UFS devices in the market uses reserved attributes and flags
although it not defined in the spec. Therefore this commit give option
to the tool read/write reserved attributes & flags