### PR TITLE
ufs: ffu: Increase chunk size for ufs ffu

### DIFF
--- a/options.c
+++ b/options.c
@@ -663,7 +663,7 @@ static int verify_arg_and_set_default(struct tool_options *options)
 
 	if (options->config_type_inx == FFU_TYPE) {
 		if (options->size == INVALID)
-			options->size = MAX_IOCTL_BUF_SIZE;
+			options->size = DEFAULT_IOCTL_BUF_SIZE;
 		if (options->idn == INVALID)
 			/*Default operation*/
 			options->idn = UFS_FFU;

--- a/ufs.h
+++ b/ufs.h
@@ -10,11 +10,12 @@
 #define BLOCK_SIZE 512
 
 /*
- * Generally the max HW max chunk is 512KB,
- * but in order to be in safe side tool using 256KB as max chunk size
- * between user and kernel space
+ * Generally the max HW max chunk is 512KB
+ * Default chunk size is 256KB
 */
-#define MAX_IOCTL_BUF_SIZE (256L * 1024)
+#define MAX_IOCTL_BUF_SIZE (512L * 1024)
+
+#define DEFAULT_IOCTL_BUF_SIZE (256L * 1024)
 
 #define QUERY_DESC_MAX_SIZE       255
 


### PR DESCRIPTION
1. For some specific ufs devices, they need flash entire fw once. So Increase chunk size from 256 KB to 512 KB.

TEST=ufs-utils ffu -t 0 -p /dev/bsg/0\:0\:0\:0 -w FW.bin