### PR TITLE
ufs-utils: arpmb: Add UFS 4.0 advanced RPMB support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ objects = \
 	hmac_sha2.o \
 	sha2.o \
 	ufs_rpmb.o \
+	ufs_arpmb.o \
 	ufs_hmr.o
 
 CHECKFLAGS = -Wall  -Wundef -Wno-missing-braces

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Output:
         ufs-utils -v
                 Show the version.
 
-        ufs-utils <desc | attr | fl | err_hist | uic | ffu | vendor | rpmb | hmr> --help|-h
+        ufs-utils <desc | attr | fl | err_hist | uic | ffu | vendor | rpmb | hmr | arpmb> --help|-h
                 Show detailed help for a command
 
     Run the tool's help for the ufs configuration features in order to

--- a/options.c
+++ b/options.c
@@ -101,7 +101,8 @@ int init_options(int opt_cnt, char *opt_arr[], struct tool_options *options)
 		case 's':
 			if (options->config_type_inx == FFU_TYPE)
 				rc = verify_and_set_ffu_chunk_size(options);
-			else if (options->config_type_inx == RPMB_CMD_TYPE)
+			else if (options->config_type_inx == RPMB_CMD_TYPE ||
+				 options->config_type_inx == ARPMB_CMD_TYPE)
 				rc = verify_and_set_start_addr(options);
 			else
 				rc = verify_and_set_selector(options);
@@ -288,6 +289,7 @@ static int verify_and_set_idn(struct tool_options *options)
 		}
 		break;
 	case RPMB_CMD_TYPE:
+	case ARPMB_CMD_TYPE:
 		if (idn >= RPMB_CMD_MAX) {
 			print_error("Invalid rpmb cmd %d", idn);
 			goto out;
@@ -359,7 +361,7 @@ static int verify_and_set_start_addr(struct tool_options *options)
 {
 	int start_block = 0;
 
-	if (options->config_type_inx != RPMB_CMD_TYPE) {
+	if (options->config_type_inx != RPMB_CMD_TYPE && options->config_type_inx != ARPMB_CMD_TYPE) {
 		print_error("start block address using only for rpmb cmd");
 		goto out;
 	}
@@ -381,7 +383,7 @@ static int verify_and_set_num_block(struct tool_options *options)
 {
 	int num_block = 0;
 
-	if (options->config_type_inx != RPMB_CMD_TYPE) {
+	if (options->config_type_inx != RPMB_CMD_TYPE && options->config_type_inx != ARPMB_CMD_TYPE) {
 		print_error("num_block using only for rpmb cmd");
 		goto out;
 	}
@@ -401,7 +403,7 @@ out:
 
 static int verify_and_set_key_path(struct tool_options *options)
 {
-	if (options->config_type_inx != RPMB_CMD_TYPE) {
+	if (options->config_type_inx != RPMB_CMD_TYPE && options->config_type_inx != ARPMB_CMD_TYPE) {
 		print_error("key path using only for rpmb cmd");
 		goto out;
 	}
@@ -678,7 +680,7 @@ static int verify_arg_and_set_default(struct tool_options *options)
 	    (options->len == INVALID))
 		options->len = BLOCK_SIZE;
 
-	if (options->config_type_inx == RPMB_CMD_TYPE) {
+	if (options->config_type_inx == RPMB_CMD_TYPE || options->config_type_inx == ARPMB_CMD_TYPE) {
 		if (verify_rpmb_arg(options))
 			goto out;
 	}
@@ -793,7 +795,8 @@ static int verify_write(struct tool_options *options)
 	}
 	if (options->config_type_inx == FFU_TYPE ||
 	    options->config_type_inx == VENDOR_BUFFER_TYPE ||
-	    options->config_type_inx == RPMB_CMD_TYPE) {
+	    options->config_type_inx == RPMB_CMD_TYPE ||
+	    options->config_type_inx == ARPMB_CMD_TYPE) {
 		int len = strlen(optarg) + 1;
 
 		if (len >= PATH_MAX) {

--- a/options.h
+++ b/options.h
@@ -4,6 +4,7 @@
 #ifndef OPTIONS_H_
 #define OPTIONS_H_
 #include <stdint.h>
+#include "ufs.h"
 
 #define OK 0
 #define ERROR -1
@@ -25,7 +26,7 @@
 
 struct tool_options {
 	/* one of @ufs_cong_type */
-	int config_type_inx;
+	enum ufs_cong_type config_type_inx;
 	/* opt: -t, type - one of @flag_idn / @attr_idn / @desc_idn
 	 * or @unipro attribute idn
 	 */

--- a/scsi_bsg_util.c
+++ b/scsi_bsg_util.c
@@ -10,6 +10,8 @@
 #include <endian.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
 
 #include "ioctl.h"
 #include "ufs.h"
@@ -179,6 +181,23 @@ int scsi_security_out(int fd, struct rpmb_frame *frame_in,
 	return ret;
 }
 
+int prepare_security_cdb(__u8 *cdb, unsigned int data_len, __u8 region, __u8 opcode)
+{
+
+	if (cdb == NULL)
+		return ERROR;
+
+	__u16 sec_spec = (region << 8) | SEC_SPECIFIC_UFS_RPMB;
+
+	cdb[0] = opcode;
+	cdb[1] = SEC_PROTOCOL_UFS;
+
+	*(__u16 *)(cdb + SEC_SPEC_OFFSET) = htobe16(sec_spec);
+	*(__u32 *)(cdb + SEC_TRANS_LEN_OFFSET) = htobe32(data_len);
+
+	return 0;
+}
+
 void prepare_upiu(struct ufs_bsg_request *bsg_req,
 		__u8 query_req_func, __u16 data_len,
 		__u8 opcode, __u8 idn, __u8 index, __u8 sel)
@@ -199,6 +218,21 @@ void prepare_upiu(struct ufs_bsg_request *bsg_req,
 	bsg_req->upiu_req.qr.index = index;
 	bsg_req->upiu_req.qr.selector = sel;
 	bsg_req->upiu_req.qr.length = htobe16(data_len);
+}
+
+
+void prepare_command_upiu(struct utp_upiu_req *upiu_req, __u8 flags, __u8 lun, __u8 ehs_len,
+			  __u8 *cdb, __u8 cdb_len, __u32 exp_data_transfer_len)
+{
+
+	/* Fill UPIU header */
+	upiu_req->header.dword_0 = UPIU_HEADER_DWORD(UPIU_TRANSACTION_COMMAND, flags, lun, 0);
+	upiu_req->header.dword_1 = UPIU_HEADER_DWORD(0, 0, 0, 0);
+	upiu_req->header.dword_2 = UPIU_HEADER_DWORD(ehs_len, 0, 0, 0);
+
+	/* Fill Transaction Specific Fields */
+	upiu_req->sc.exp_data_transfer_len = htobe32(exp_data_transfer_len);
+	memcpy(upiu_req->sc.cdb, cdb, cdb_len);
 }
 
 /**
@@ -296,13 +330,13 @@ static int send_scsi_cmd(int fd, const __u8 *cdb, void *buf, __u8 cmd_len,
  * @req_buf_len: Query Request data length
  * @reply_buf_len: Query Response data length
  * @data_buf: pointer to the data buffer
+ * @write: If data_buff is not NULL, it indicates that this is a data write request or data read
  *
  * The function using ufs bsg infrastructure in linux kernel (/dev/ufs-bsg)
  * in order to send Query request command
  **/
-int send_bsg_scsi_trs(int fd, struct ufs_bsg_request *request_buff,
-		struct ufs_bsg_reply *reply_buff, __u32 req_buf_len,
-		__u32 reply_buf_len, __u8 *data_buf)
+int send_bsg_scsi_trs(int fd, void *request_buff, void *reply_buff, __u32 req_buf_len,
+			__u32 reply_buf_len, __u32 data_buf_len, __u8 *data_buf, bool write)
 {
 	int ret;
 	struct sg_io_v4 io_hdr_v4 = { 0 };
@@ -312,7 +346,7 @@ int send_bsg_scsi_trs(int fd, struct ufs_bsg_request *request_buff,
 		return -EINVAL;
 	}
 
-	if (req_buf_len != 0 || reply_buf_len != 0) {
+	if (data_buf_len) {
 		if (data_buf == NULL) {
 			print_error("%s: data_buf is NULL", __func__);
 			return -EINVAL;
@@ -323,26 +357,28 @@ int send_bsg_scsi_trs(int fd, struct ufs_bsg_request *request_buff,
 	io_hdr_v4.protocol = BSG_PROTOCOL_SCSI;
 	io_hdr_v4.subprotocol = BSG_SUB_PROTOCOL_SCSI_TRANSPORT;
 	io_hdr_v4.response = (__u64)reply_buff;
-	io_hdr_v4.max_response_len = BSG_REPLY_SZ;
-	io_hdr_v4.request_len = BSG_REQUEST_SZ;
+	io_hdr_v4.max_response_len = reply_buf_len;
+	io_hdr_v4.request_len = req_buf_len;
 	io_hdr_v4.request = (__u64)request_buff;
 
-	if (req_buf_len > 0) {
-		/* write descriptor */
-		io_hdr_v4.dout_xferp = (__u64)(data_buf);
-		io_hdr_v4.dout_xfer_len = req_buf_len;
-	} else if (reply_buf_len > 0) {
-		/* read descriptor */
-		io_hdr_v4.din_xferp = (__u64)(data_buf);
-		io_hdr_v4.din_xfer_len = reply_buf_len;
+	if (data_buf) {
+		if (write) {
+			/* write descriptor */
+			io_hdr_v4.dout_xferp = (__u64)(data_buf);
+			io_hdr_v4.dout_xfer_len = data_buf_len;
+		} else  {
+			/* read descriptor */
+			io_hdr_v4.din_xferp = (__u64)(data_buf);
+			io_hdr_v4.din_xfer_len = data_buf_len;
+		}
 	}
 
-	WRITE_LOG("%s cmd = %x req_len %d , res_len %d\n", __func__,
-		request_buff->upiu_req.qr.idn, req_buf_len,
+	WRITE_LOG("%s cmd = %x req_len %d, res_len %d\n", __func__,
+		((struct ufs_bsg_request *)request_buff)->upiu_req.qr.idn, req_buf_len,
 		reply_buf_len);
 
 	write_file_with_counter("bsg_reg_%d.bin",
-				&request_buff->upiu_req,
+				&((struct ufs_bsg_request *)request_buff)->upiu_req,
 				sizeof(struct utp_upiu_req));
 
 

--- a/ufs.c
+++ b/ufs.c
@@ -28,7 +28,7 @@ typedef int (*command_function)(struct tool_options *opt);
 struct tool_command {
 	command_function func; /* function which implements the command */
 	char *conf_type; /* one of: descriptor/attributes/flags */
-	int conf_type_ind; /* confiruration type index */
+	enum ufs_cong_type conf_type_ind; /* confiruration type index */
 };
 
 static struct tool_command commands[] = {
@@ -43,6 +43,7 @@ static struct tool_command commands[] = {
 	{ do_ffu, "ffu", FFU_TYPE},
 	{ do_vendor, "vendor", VENDOR_BUFFER_TYPE},
 	{ do_rpmb, "rpmb", RPMB_CMD_TYPE},
+	{ do_arpmb, "arpmb", ARPMB_CMD_TYPE},
 	{ do_hmr, "hmr", HMR_TYPE},
 	{ do_get_ufs_spec_ver, "spec_version", SPEC_VERSION},
 	{ do_get_ufs_bsg_list, "list_bsg", BSG_LIST_TYPE},
@@ -67,7 +68,7 @@ static void help(char *np)
 	char help_str[256] = {0};
 
 	strcat(help_str, "<desc | attr | fl | err_hist | uic | ffu | vendor | "
-		"rpmb | hmr | spec_version | list_bsg>");
+		"rpmb | hmr | spec_version | list_bsg | arpmb>");
 	printf("\n Usage:\n");
 	printf("\n\t%s help|--help|-h\n\t\tShow the help.\n", np);
 	printf("\n\t%s -v\n\t\tShow the version.\n", np);
@@ -209,6 +210,9 @@ void print_command_help(char *prgname, int config_type)
 		break;
 	case RPMB_CMD_TYPE:
 		rpmb_help(prgname);
+		break;
+	case ARPMB_CMD_TYPE:
+		arpmb_help(prgname);
 		break;
 	case HMR_TYPE:
 		hmr_help(prgname);

--- a/ufs.h
+++ b/ufs.h
@@ -166,6 +166,7 @@ enum ufs_cong_type {
 	FFU_TYPE,
 	VENDOR_BUFFER_TYPE,
 	RPMB_CMD_TYPE,
+	ARPMB_CMD_TYPE,
 	HMR_TYPE,
 	SPEC_VERSION,
 	BSG_LIST_TYPE
@@ -178,6 +179,8 @@ enum {
 	UPIU_TRANSACTION_DATA_OUT	= 0x02,
 	UPIU_TRANSACTION_TASK_REQ	= 0x04,
 	UPIU_TRANSACTION_QUERY_REQ	= 0x16,
+	UPIU_TRANSACTION_UIC_CMD	= 0x1F,
+	UPIU_TRANSACTION_ARPMB_CMD	= 0x20,
 };
 
 int write_file(const char *name, const void *buffer, int length);

--- a/ufs_arpmb.c
+++ b/ufs_arpmb.c
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Most of the source code refers to ufs_rpmb.c,
+ * And changed and updated by:
+ *	Bean Huo <beanhuo@micron.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <endian.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdbool.h>
+#include "ufs.h"
+#include "ufs_cmds.h"
+#include "options.h"
+#include "ufs_rpmb.h"
+#include "hmac_sha2.h"
+#include "scsi_bsg_util.h"
+
+static unsigned char key_buff[RPMB_KEY_SIZE];
+
+extern int do_read_desc(int fd, struct ufs_bsg_request *bsg_req, struct ufs_bsg_reply *bsg_rsp,
+			__u8 idn, __u8 index, __u16 desc_buf_len, __u8 *data_buf);
+
+static int arpmb_calc_hmac_sha256(struct ufs_ehs *ehs, __u8 *data, size_t len,
+				  const unsigned char key[], __u32 key_size,
+				  unsigned char mac[], __u32 mac_size)
+{
+	hmac_sha256_ctx ctx;
+	char padding[4];
+
+	hmac_sha256_init(&ctx, key, key_size);
+
+	/*
+	 * If RPMB Message includes data in a DATA IN UPIU or a DATA OUT UPIU, the concatenation
+	 * of the data transferred in each DATA IN/OUT UPIU in the order in which it is sent is
+	 * input into the MAC calculation. Then the concatenation of the fields in the Advanced
+	 * RPMB Meta Information from byte 0 to byte 27 is input into the MAC calculation. After
+	 * this, four 00h bytes are input into the MAC calculation.
+	 */
+	hmac_sha256_update(&ctx, CUC(data), len);
+	hmac_sha256_update(&ctx, CUC(ehs->meta_bytes), 28);
+	hmac_sha256_update(&ctx, CUC(padding), 4);
+
+	hmac_sha256_final(&ctx, mac, mac_size);
+
+	return 0;
+}
+
+
+static int do_arpmb_op(int ufs_bsg_fd, struct ufs_rpmb_request *ufs_arpmb_req,
+		       struct ufs_rpmb_reply *ufs_arpmb_resp,
+		       __u8 region, __u32 len, __u8 *data, enum rpmb_op_type op)
+{
+	__u8 cdb[SEC_PROTOCOL_CMD_SIZE] = {0};
+	bool write =  false;
+	int ret = -EINVAL;
+	__u8 opcode;
+	__u8 flags;
+
+	if (!ufs_arpmb_req || !ufs_arpmb_resp) {
+		print_error("Wrong arpmb parameters");
+		goto out;
+	}
+
+	switch (op) {
+	case RPMB_WRITE_KEY:
+		opcode = SECURITY_PROTOCOL_OUT;
+		write = true;
+		flags = 0x20;
+		break;
+	case RPMB_READ_CNT:
+		opcode = SECURITY_PROTOCOL_IN;
+		flags = 0x40;
+		break;
+	case RPMB_READ:
+		opcode = SECURITY_PROTOCOL_IN;
+		flags = 0x40;
+		break;
+	case RPMB_WRITE:
+		opcode = SECURITY_PROTOCOL_OUT;
+		write = true;
+		flags = 0x20;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	prepare_security_cdb(cdb, len, region, opcode);
+	prepare_command_upiu(&ufs_arpmb_req->bsg_request.upiu_req, flags, 0xC4, 2, cdb,
+				SEC_PROTOCOL_CMD_SIZE, len);
+
+	ufs_arpmb_req->bsg_request.msgcode = UPIU_TRANSACTION_ARPMB_CMD;
+
+	ret = send_bsg_scsi_trs(ufs_bsg_fd, ufs_arpmb_req, ufs_arpmb_resp,
+			       sizeof(struct ufs_rpmb_request), sizeof(struct ufs_rpmb_reply),
+			       len, data, write);
+	if (!ret) {
+
+		if (be32toh(ufs_arpmb_resp->bsg_reply.upiu_rsp.header.dword_1) & 0xFFFF) {
+			print_error("ARPMB CMD failed, with response in UPIU 0x%x, status 0x%x.\n",
+			(be32toh(ufs_arpmb_resp->bsg_reply.upiu_rsp.header.dword_1) & 0xFF00) >> 8,
+			be32toh(ufs_arpmb_resp->bsg_reply.upiu_rsp.header.dword_1) & 0xFF);
+
+			ret  = -EINVAL;
+		} else if (ufs_arpmb_resp->bsg_reply.result) {
+			print_error("ARPMB OP failed %d :%d\n", ret,
+					ufs_arpmb_resp->bsg_reply.result);
+
+			ret = ret ? : ufs_arpmb_resp->bsg_reply.result;
+		}
+	}
+
+out:
+	return ret;
+}
+
+static int do_arpmb_key(int ufs_bsg_fd, const unsigned char *key, __u8 region)
+{
+	struct ufs_rpmb_request ufs_arpmb_req = { 0 };
+	struct ufs_rpmb_reply ufs_arpmb_resp = { 0 };
+	int ret = INVALID;
+
+	if (key == NULL) {
+		WRITE_LOG0("key is NULL");
+		goto out;
+	}
+
+	ufs_arpmb_req.ehs_req.blenght = 0x02;
+	ufs_arpmb_req.ehs_req.lehs_type = 0x01;
+	ufs_arpmb_req.ehs_req.meta.req_resp_type = htobe16(RPMB_WRITE_KEY);
+
+	memcpy(ufs_arpmb_req.ehs_req.mac_key, key, sizeof(ufs_arpmb_req.ehs_req.mac_key));
+	WRITE_LOG("Start : %s\n", __func__);
+	ret = do_arpmb_op(ufs_bsg_fd, &ufs_arpmb_req, &ufs_arpmb_resp, region, 0, NULL,
+			  RPMB_WRITE_KEY);
+
+	if (!ret) {
+		if (ufs_arpmb_resp.ehs_rsp.meta.result != 0) {
+			print_operation_error(be16toh(ufs_arpmb_resp.ehs_rsp.meta.result));
+			goto out;
+		} else {
+			printf("ARPMB key is programmed\n");
+		}
+	}
+out:
+	return ret;
+}
+
+static int do_arpmb_read_counter(int fd, __u32 *cnt, __u8 region, __u8 sg_type, bool prn_cnt)
+{
+	struct ufs_rpmb_request ufs_arpmb_req = { 0 };
+	struct ufs_rpmb_reply ufs_arpmb_resp = { 0 };
+	int ret;
+
+	WRITE_LOG("Start : %s %d\n", __func__, region);
+
+	ufs_arpmb_req.ehs_req.blenght = 0x02;
+	ufs_arpmb_req.ehs_req.lehs_type = 0x01;
+	ufs_arpmb_req.ehs_req.meta.req_resp_type = htobe16(RPMB_READ_CNT);
+
+	ret = do_arpmb_op(fd, &ufs_arpmb_req, &ufs_arpmb_resp, region, 0, 0, RPMB_READ_CNT);
+
+	if (!ret) {
+		if (ufs_arpmb_resp.ehs_rsp.meta.result != 0) {
+			print_operation_error(be16toh(ufs_arpmb_resp.ehs_rsp.meta.result));
+		} else {
+			if (prn_cnt)
+				printf("ARPMB write counter = %u\n",
+					be32toh(ufs_arpmb_resp.ehs_rsp.meta.write_counter));
+			*cnt = be32toh(ufs_arpmb_resp.ehs_rsp.meta.write_counter);
+		}
+	}
+
+	return ret;
+}
+
+static int do_read_arpmb(int fd, int out_fd, unsigned char *key, int start_addr,
+			int num_blocks, __u8 region)
+{
+	struct ufs_bsg_request bsg_req = { 0 };
+	struct ufs_bsg_reply bsg_rsp = { 0 };
+	int ret = ERROR;
+	ssize_t write_size;
+	__u8 max_num_blocks;
+	__u8 num_read_blocks = 0;
+	__u8 *buff = NULL;
+
+	struct ufs_rpmb_request ufs_arpmb_req = { 0 };
+	struct ufs_rpmb_reply ufs_arpmb_rsp = { 0 };
+	__u8 data_buf[QUERY_DESC_GEOMETRY_MAX_SIZE] = { 0 };
+
+	WRITE_LOG("Start : %s , address %d , num_blocks %d\n", __func__, start_addr, num_blocks);
+
+	ret = do_read_desc(fd, &bsg_req, &bsg_rsp, QUERY_DESC_IDN_GEOMETRY, 0,
+				QUERY_DESC_GEOMETRY_MAX_SIZE, data_buf);
+
+	if (ret) {
+		/* Could not read geometry descriptor, max block set DEFAULT_RPMB_NUM_BLOCKS */
+		print_warn("Cannot get bRPMB_ReadWriteSize");
+		max_num_blocks = DEFAULT_RPMB_NUM_BLOCKS;
+	} else {
+		max_num_blocks = data_buf[0x17];
+		WRITE_LOG("max_num_blocks : %d\n", max_num_blocks);
+	}
+
+	if (num_blocks > max_num_blocks)
+		num_read_blocks = max_num_blocks;
+	else
+		num_read_blocks = num_blocks;
+
+	while (num_blocks > 0) {
+		if (start_addr > ARPMB_MAX_ADDRESS) {
+			print_error("Max available address is reached");
+			goto out;
+		}
+
+		buff = calloc(num_read_blocks, 4096);
+		if (!buff) {
+			print_error("Cannot allocate %d RPMB frames",
+					num_blocks);
+			goto out;
+		}
+
+		ufs_arpmb_req.ehs_req.blenght = 0x02;
+		ufs_arpmb_req.ehs_req.lehs_type = 0x01;
+		ufs_arpmb_req.ehs_req.meta.req_resp_type = htobe16(RPMB_READ);
+		ufs_arpmb_req.ehs_req.meta.addr = htobe16(start_addr);
+		ufs_arpmb_req.ehs_req.meta.block_count = htobe16(num_read_blocks);
+		ret = do_arpmb_op(fd, &ufs_arpmb_req, &ufs_arpmb_rsp, region,
+				  num_read_blocks * 4096, buff, RPMB_READ);
+		if (ret != 0) {
+			print_error("ARPMB operation is failed in addr %d ", start_addr);
+			goto out;
+		}
+		if (ufs_arpmb_rsp.ehs_rsp.meta.result != 0) {
+			print_operation_error(be16toh(ufs_arpmb_rsp.ehs_rsp.meta.result));
+			ret = -EINVAL;
+			goto out;
+		}
+
+		/* In case an user get the key, verify the hash */
+		if (key != NULL) {
+			__u8 mac[RPMB_MAC_SIZE];
+
+			arpmb_calc_hmac_sha256(&ufs_arpmb_rsp.ehs_rsp, buff, num_read_blocks * 4096,
+					      key, RPMB_KEY_SIZE, mac, RPMB_MAC_SIZE);
+			/*
+			 * Compare calculated MAC and MAC from last frame
+			 * Note the mac much only in case we read 1 block ,
+			 * otherwise the mac field is not much, in all frame ,
+			 * include the last one
+			 */
+			if (memcmp(mac, ufs_arpmb_rsp.ehs_rsp.mac_key, sizeof(mac)))
+				print_warn("ARPMB MAC mismatch mac");
+		}
+
+
+		write_size = write(out_fd, buff, num_read_blocks * 4096);
+		if (write_size  !=  num_read_blocks * 4096) {
+			printf("%s: failed in write sz=%d errno=%d\n", __func__,
+				(int)write_size, errno);
+			ret = INVALID;
+			goto out;
+		}
+
+		WRITE_LOG("num_blocks : %d start_addr %d num_read_blocks %d\n", num_blocks,
+				start_addr, num_read_blocks);
+		num_blocks = num_blocks - num_read_blocks;
+		start_addr = start_addr + num_read_blocks;
+
+		if (num_blocks > max_num_blocks)
+			num_read_blocks = max_num_blocks;
+		else
+			num_read_blocks = num_blocks;
+
+		if (buff) {
+			free(buff);
+			buff = NULL;
+		}
+	}
+out:
+	if (buff)
+		free(buff);
+
+	return ret;
+}
+
+static int do_write_arpmb(int fd, const unsigned char *key, int input_fd, __u32 cnt,
+			int start_addr, int num_blocks, __u8 region, __u8 sg_type)
+{
+	struct ufs_bsg_request bsg_req = { 0 };
+	struct ufs_bsg_reply bsg_rsp = { 0 };
+	unsigned char mac[RPMB_MAC_SIZE];
+	int ret = ERROR;
+	__u8 *buff;
+	__u8 max_num_blocks;
+	ssize_t read_size = 0;
+	__u8 num_write_blocks = 0;
+	int j = 0;
+
+	struct ufs_rpmb_request ufs_arpmb_req = { 0 };
+	struct ufs_rpmb_reply ufs_arpmb_rsp = { 0 };
+	__u8 data_buf[QUERY_DESC_GEOMETRY_MAX_SIZE] = { 0 };
+
+	WRITE_LOG("Start : %s\n", __func__);
+
+	ret = do_read_desc(fd, &bsg_req, &bsg_rsp, QUERY_DESC_IDN_GEOMETRY, 0,
+				QUERY_DESC_GEOMETRY_MAX_SIZE, data_buf);
+
+	if (ret) {
+		print_warn("Cannot get bRPMB_ReadWriteSize");
+		max_num_blocks = DEFAULT_RPMB_NUM_BLOCKS;
+	} else {
+		max_num_blocks = data_buf[0x17];
+		if (max_num_blocks <= 0)
+			max_num_blocks = 1;
+		ret = OK;
+	}
+
+	if (num_blocks > max_num_blocks)
+		num_write_blocks = max_num_blocks;
+	else
+		num_write_blocks = num_blocks;
+
+	WRITE_LOG("max_num_blocks : %d num_block %d, cnt %d start_addr %d\n",
+		max_num_blocks, num_write_blocks, cnt, start_addr);
+
+	while (num_blocks > 0) {
+		if (start_addr > ARPMB_MAX_ADDRESS) {
+			print_error("Max available address is reached");
+			goto out;
+		}
+
+		buff = calloc(num_write_blocks, 4096);
+		if (!buff) {
+			print_error("Cannot allocate %d RPMB frames", num_blocks);
+			ret = -ENOMEM;
+			goto out;
+		}
+
+		read_size = read(input_fd, buff, num_write_blocks * 4096);
+		if (read_size != num_write_blocks * 4096) {
+
+			WRITE_LOG("%s: failed in read size=%d errno=%d",
+				  __func__, (int)read_size, errno);
+			ret = -EINVAL;
+			goto out;
+		}
+
+		ufs_arpmb_req.ehs_req.blenght = 0x02;
+		ufs_arpmb_req.ehs_req.lehs_type = 0x01;
+		ufs_arpmb_req.ehs_req.meta.req_resp_type = htobe16(RPMB_WRITE);
+		ufs_arpmb_req.ehs_req.meta.addr = htobe16(start_addr);
+		ufs_arpmb_req.ehs_req.meta.block_count =   htobe16(num_write_blocks);
+		ufs_arpmb_req.ehs_req.meta.write_counter = htobe32(cnt);
+
+		arpmb_calc_hmac_sha256(&ufs_arpmb_req.ehs_req, buff, read_size,
+				       key, RPMB_KEY_SIZE, mac, RPMB_MAC_SIZE);
+
+		memcpy(ufs_arpmb_req.ehs_req.mac_key, mac, RPMB_MAC_SIZE);
+
+		ret = do_arpmb_op(fd, &ufs_arpmb_req, &ufs_arpmb_rsp,
+				  region, num_write_blocks * 4096, buff, RPMB_WRITE);
+		if (ret != 0)
+			goto out;
+
+		/* Check RPMB response */
+		if (ufs_arpmb_rsp.ehs_rsp.meta.result != 0) {
+			print_operation_error(be16toh(ufs_arpmb_rsp.ehs_rsp.meta.result));
+			ret = -EINVAL;
+			goto out;
+		}
+
+		WRITE_LOG("num_blocks : %d start_addr %d num_write_blocks %d ,iter %d,cnt %d\n",
+			  num_blocks, start_addr, num_write_blocks, j, cnt);
+
+		num_blocks = num_blocks - num_write_blocks;
+		start_addr = start_addr + num_write_blocks;
+		if (num_blocks > max_num_blocks)
+			num_write_blocks = max_num_blocks;
+		else
+			num_write_blocks = num_blocks;
+		j++;
+		cnt++;
+		if (buff) {
+			free(buff);
+			buff = NULL;
+		}
+
+	}
+out:
+	if (buff)
+		free(buff);
+	return ret;
+}
+
+int do_arpmb(struct tool_options *opt)
+{
+	unsigned char *key_ptr = NULL;
+	int output_fd = INVALID;
+	int rc = INVALID;
+	int fd;
+	__u32 cnt = 0;
+
+	fd = open(opt->path, O_RDWR | O_SYNC);
+	if (fd < 0) {
+		perror("open");
+		return ERROR;
+	}
+
+	switch (opt->idn) {
+	case AUTHENTICATION_KEY:
+		key_ptr = get_auth_key(opt->keypath, key_buff);
+		if (key_ptr == NULL)
+			goto out;
+		rc = do_arpmb_key(fd, key_ptr, opt->region);
+		break;
+	case READ_WRITE_COUNTER:
+		rc = do_arpmb_read_counter(fd, &cnt, opt->region, opt->sg_type, true);
+		break;
+	case READ_RPMB:
+		output_fd = open(opt->data, O_WRONLY | O_CREAT | O_SYNC, S_IRUSR | S_IWUSR);
+		if (output_fd < 0) {
+			perror("Output file open");
+			goto out;
+		}
+
+		if (opt->keypath[0] != 0) {
+			key_ptr = get_auth_key(opt->keypath, key_buff);
+			if (key_ptr == NULL)
+				goto out;
+		}
+
+		rc = do_read_arpmb(fd, output_fd, key_ptr, opt->start_block, opt->num_block,
+					opt->region);
+		if (!rc)
+			printf("Finish to read ARPMB data\n");
+		break;
+	case WRITE_RPMB:
+		key_ptr = get_auth_key(opt->keypath, key_buff);
+		if (key_ptr == NULL)
+			goto out;
+
+		output_fd = open(opt->data, O_RDONLY | O_SYNC);
+		if (output_fd < 0) {
+			perror("Input file open");
+			goto out;
+		}
+
+		rc = do_arpmb_read_counter(fd, &cnt, opt->region, opt->sg_type, false);
+		if (rc)
+			goto out;
+
+		rc = do_write_arpmb(fd, key_ptr, output_fd, cnt, opt->start_block, opt->num_block,
+				opt->region, opt->sg_type);
+		if (!rc)
+			printf("Finish to write ARPMB data\n");
+		break;
+	default:
+		print_error("Unsupported ARPMB cmd %d", opt->idn);
+		break;
+	}
+out:
+	if (output_fd != INVALID)
+		close(output_fd);
+	close(fd);
+
+	return rc;
+}
+
+void arpmb_help(char *tool_name)
+{
+	printf("\n Advanced RPMB command usage:\n");
+	printf("\n\t%s arpmb [-t] <rpmb cmd idn> [-p] <UFS BSG device>"
+		" -k <path to key_file> -n <block_count> -w <output/input file>.\n", tool_name);
+	printf("\n\t-t\t RPMB cmd type idn in advanced RPMB mode\n"
+		"\t\t\t0:\tKey provision\n"
+		"\t\t\t1:\tRead Write counter\n"
+		"\t\t\t2:\tRead RPMB data\n"
+		"\t\t\t3:\tWrite RPMB data\n");
+
+	printf("\n\t-s\t RPMB start address (default value is 0)\n");
+	printf("\n\t-n\t RPMB read/write blocks (default value is 1, the block size is 4KB)\n");
+	printf("\n\t-p\t ufs_bsg device path\n");
+	printf("\n\t-k\t path to RPMB key file\n");
+	printf("\n\t-w\t path to data file for read/write\n");
+	printf("\n\t-m\t RPMB region.\n");
+
+	printf("\n\tExample 1 - Read 8KB of data from RPMB LUN started "
+		"from address 0 to output file\n"
+		"\t\t  %s arpmb -t 2 -p /dev/bsg/ufs_bsg0 -s 0 -n 2 -w output_file\n", tool_name);
+	printf("\n\tExample 2 - Write RPMB key\n"
+		"\t\t  %s arpmb -t 0 -p /dev/bsg/ufs_bsg0 -k key_file\n", tool_name);
+	printf("\n\tExample 3 - Write RPMB key to region 2\n"
+		"\t\t  %s arpmb -t 0 -m 2 -p /dev/bsg/ufs_bsg0 -k key_file\n", tool_name);
+}

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -1892,15 +1892,18 @@ int do_query_rq(int fd, struct ufs_bsg_request *bsg_req,
 	int rc = OK;
 	__u8 res_code;
 	__u16 len = res_buf_len;
+	bool write =  false;
 
-	if (req_buf_len > 0)
+	if (req_buf_len > 0) {
 		len = req_buf_len;
+		write = true;
+	}
 
 	prepare_upiu(bsg_req, query_req_func, len, opcode, idn,
 		index, sel);
 
-	rc = send_bsg_scsi_trs(fd, bsg_req, bsg_rsp, req_buf_len, res_buf_len,
-			data_buf);
+	rc = send_bsg_scsi_trs(fd, bsg_req, bsg_rsp, sizeof(*bsg_req), sizeof(*bsg_rsp),
+			        len, data_buf, write);
 
 	if (rc) {
 		print_error("%s: query failed, status %d idn: %d, i: %d, s: %d",

--- a/ufs_rpmb.h
+++ b/ufs_rpmb.h
@@ -2,10 +2,31 @@
 /* Copyright (C) 2019 Western Digital Corporation or its affiliates */
 
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include "options.h"
 
 #ifndef UFS_RPMB_H_
 #define UFS_RPMB_H_
+
+#define RPMB_KEY_SIZE 32
+#define RPMB_MAC_SIZE 32
+#define RPMB_NONCE_SIZE 16
+#define RPMB_DATA_SIZE 256
+
+#define DEFAULT_RPMB_NUM_BLOCKS 64
+
+/* RPMB Data Area: 128 Kbytes minimum, 16 Mbytes maximum.
+ * For the normal RPMB mode, since the data packed in RPMB message, the size of each frame is 256
+ * bytes. so its MAX_ADDRESS == 0xFFFF.
+ *
+ * For the ADvanced RPMB mode, the Data Transfer Length unit is 4KB, so its MAX_ADDRESS ==
+ * 16MB / 4KB = 0xFFF. Note: the address starts at 0x00
+ */
+#define MAX_ADDRESS 0xFFFF
+#define ARPMB_MAX_ADDRESS 0xFFF
+
+#define CUC(x) ((const unsigned char *)(x))
 
 enum rpmb_cmd_type {
 	AUTHENTICATION_KEY = 0,
@@ -17,7 +38,68 @@ enum rpmb_cmd_type {
 	RPMB_CMD_MAX
 };
 
+enum rpmb_op_type {
+        RPMB_WRITE_KEY      = 0x01,
+        RPMB_READ_CNT       = 0x02,
+        RPMB_WRITE          = 0x03,
+        RPMB_READ           = 0x04,
+        RPMB_READ_RESP      = 0x05,
+        RPMB_SEC_CONF_WRITE = 0x06,
+        RPMB_SEC_CONF_READ  = 0x07,
+
+};
+
+/* description of the sense key values */
+static const char *const rpmb_res_txt[] = {
+        "Success",
+        "General failure",
+        "Authentication failure",
+        "Counter failure",
+        "Address failure",
+        "Write failure",
+        "Read failure",
+        "Authentication Key not yet programmed",
+        "Secure Write Protect Configuration Block access failure",
+        "Invalid Secure Write Protect Block Configuration parameter",
+        "Secure Write Protection not applicable"
+};
+
 void rpmb_help(char *tool_name);
 int do_rpmb(struct tool_options *opt);
+void arpmb_help(char *tool_name);
+int do_arpmb(struct tool_options *opt);
 
+static inline void  print_operation_error(__u16 result)
+{
+	if (result <= 0xA)
+		printf("\n %s\n", rpmb_res_txt[result]);
+	else
+		printf("\n Unsupported RPMB Operation Error %x\n", result);
+}
+
+static inline unsigned char *get_auth_key(char *key_path, unsigned char * key_buff)
+{
+        unsigned char *pkey = NULL;
+        int key_fd = INVALID;
+        ssize_t read_size;
+
+        if (key_path == NULL || key_buff == NULL)
+                return NULL;
+
+        key_fd = open(key_path, O_RDONLY);
+        if (key_fd < 0) {
+                perror("Key file open");
+        } else {
+                read_size = read(key_fd, key_buff, RPMB_KEY_SIZE);
+                if (read_size < RPMB_KEY_SIZE) {
+                        print_error("Key must be %d bytes length,was read %d",
+                                    RPMB_KEY_SIZE, read_size);
+                } else
+                        pkey = key_buff;
+        }
+
+        if (key_fd != INVALID)
+                close(key_fd);
+        return pkey;
+}
 #endif /* UFS_RPMB_H_ */

--- a/unipro.c
+++ b/unipro.c
@@ -286,7 +286,8 @@ static int ufshcd_dme_get_attr(int fd, __u32 attr_sel, __u8 peer)
 	uic_cmd->argument1 = attr_sel;
 	bsg_req.msgcode = UPIU_TRANSACTION_UIC_CMD;
 
-	rt = send_bsg_scsi_trs(fd, &bsg_req, &bsg_rsp, 0, 0, 0);
+	rt = send_bsg_scsi_trs(fd, &bsg_req, &bsg_rsp, sizeof(struct ufs_bsg_request),
+			       sizeof(struct ufs_bsg_reply), 0, 0, 0);
 	if (rt) {
 		print_error("%s: bsg request failed", __func__);
 		rt = ERROR;
@@ -340,7 +341,8 @@ static int ufshcd_dme_set_attr(int fd, __u32 attr_sel, __u8 attr_set,
 
 	bsg_req.msgcode = UPIU_TRANSACTION_UIC_CMD;
 
-	rt = send_bsg_scsi_trs(fd, &bsg_req, &bsg_rsp, 0, 0, 0);
+	rt = send_bsg_scsi_trs(fd, &bsg_req, &bsg_rsp, sizeof(struct ufs_bsg_request),
+			       sizeof(struct ufs_bsg_reply), 0, 0, 0);
 	if (rt) {
 		print_error("%s: bsg request failed", __func__);
 		rt = ERROR;

--- a/unipro.h
+++ b/unipro.h
@@ -21,7 +21,6 @@
 #define ATTR_SET_ST     1       /* STATIC */
 #define MASK_UIC_COMMAND_RESULT 0xFF
 
-#define UPIU_TRANSACTION_UIC_CMD 0x1F
 /* uic commands are 4DW long, per UFSHCI V2.1 paragraph 5.6.1 */
 #define UIC_CMD_SIZE (sizeof(__u32) * 4)
 


### PR DESCRIPTION
UFS 4.0 Advanced RPMB is enabled in the upstream Linux kernel since V6.3, so we can add UFS 4.0 Advanced RPMB support in ufs-utils,