### PR TITLE
Fix return value error at config desc with D option

### DIFF
--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -1455,6 +1455,7 @@ static int do_conf_desc(int fd, __u8 opt, __u8 index, char *data_file)
 			}
 			printf("Config Descriptor was written into %s file\n",
 			       data_file);
+			rc = 0;
 		}
 	}
 out:


### PR DESCRIPTION
When the user uses the D option, a data file is created through the store_data_file(). However, this function returns the size of the data. Therefore, despite normal operation, rc becomes a non-zero value and eventually returns an error 1 in the application return.