### PR TITLE
Fix return value error at various desc with D option

### DIFF
--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -1175,6 +1175,7 @@ static int do_unit_desc(int fd, __u8 lun, char *data_file)
 			goto out;
 		}
 		printf("Unit Descriptor was written into %s file\n", data_file);
+		rc = 0;
 	}
 
 out:
@@ -1209,6 +1210,7 @@ static int do_interconnect_desc(int fd, char *data_file)
 		}
 		printf("Interconnect Descriptor was written into %s file\n",
 		       data_file);
+		rc = 0;
 	}
 out:
 	return rc;
@@ -1241,6 +1243,7 @@ static int do_geo_desc(int fd, char *data_file)
 		}
 		printf("Geometry Descriptor was written into %s file\n",
 		       data_file);
+		rc = 0;
 	}
 
 out:
@@ -1283,6 +1286,7 @@ static int do_power_desc(int fd, char *data_file)
 		}
 		printf("Power Descriptor was written into %s file\n",
 		       data_file);
+		rc = 0;
 	}
 
 out:
@@ -1315,6 +1319,7 @@ static int do_health_desc(int fd, char *data_file)
 		}
 		printf("Device Health Descriptor was written into %s file\n",
 		       data_file);
+		rc = 0;
 	}
 
 out:
@@ -1367,6 +1372,7 @@ static int do_string_desc(int fd, char *str_data, __u8 idn, __u8 opr,
 			}
 			printf("String Descriptor was written into %s file\n",
 			       data_file);
+			rc = 0;
 		}
 	}
 out:
@@ -1498,6 +1504,7 @@ int do_vendor_desc(int fd, __u8 opt, __u8 idn, char *data_file)
 			}
 			printf("Reserved/Vendor Descriptor was written into %s file\n",
 			       data_file);
+			rc = 0;
 		}
 	}
 
@@ -1791,6 +1798,7 @@ int do_device_desc(int fd, __u8 *desc_buff, char *data_file)
 		}
 		printf("Device Descriptor was written into %s file\n",
 		       data_file);
+		rc = 0;
 	}
 
 out:


### PR DESCRIPTION
When the user uses the D option, a data file is created through the store_data_file(). However, this function returns the size of the data. Therefore, despite normal operation, rc becomes a non-zero value and eventually returns an error 1 in the application return.