### PR TITLE
feat: add max descriptor size for Samsung Vendor Spec

### DIFF
--- a/ufs.h
+++ b/ufs.h
@@ -161,7 +161,11 @@ enum ufs_desc_max_size {
 	QUERY_DESC_INTERCONNECT_MAX_SIZE	= 0x06,
 	QUERY_DESC_POWER_MAX_SIZE		= 0x62,
 	QUERY_DESC_HEALTH_MAX_SIZE		= 0x2d,
-	QUERY_DESC_FBO_MAX_SIZE			= 0x12
+	QUERY_DESC_FBO_MAX_SIZE			= 0x12,
+
+	/* Max desciptor size from 2.1 to 3.0 MX Vendor UFS spec */
+	QUERY_DESC_DEVICE_MAX_SIZE_VENDOR_SS_MX         = 0x5F,
+	QUERY_DESC_GEOMETRY_MAX_SIZE_VENDOR_SS_MX       = 0x59
 };
 
 /* UPIU Read/Write flags */

--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -1598,6 +1598,7 @@ static int check_read_desc_size(__u8 idn, __u8 *data_buf)
 	switch (idn) {
 	case QUERY_DESC_IDN_DEVICE:
 		if ((data_buf[0] != QUERY_DESC_DEVICE_MAX_SIZE) &&
+		    (data_buf[0] != QUERY_DESC_DEVICE_MAX_SIZE_VENDOR_SS_MX) &&
 		    (data_buf[0] != QUERY_DESC_DEVICE_MAX_SIZE_3_0))
 			unoff = true;
 		break;
@@ -1617,6 +1618,7 @@ static int check_read_desc_size(__u8 idn, __u8 *data_buf)
 		break;
 	case QUERY_DESC_IDN_GEOMETRY:
 		if ((data_buf[0] != QUERY_DESC_GEOMETRY_MAX_SIZE) &&
+		    (data_buf[0] != QUERY_DESC_GEOMETRY_MAX_SIZE_VENDOR_SS_MX) &&
 		    (data_buf[0] != QUERY_DESC_GEOMETRY_MAX_SIZE_3_0) &&
 		    (data_buf[0] != QUERY_DESC_GEOMETRY_MAX_SIZE_4_1))
 			unoff = true;


### PR DESCRIPTION
Feat: add max descriptor size for Samsung vendor Spec

This PR is intended to ensure that
validation with ufs-utils can be performed smoothly
even if the Descriptor Max Size changes during new feature development.



To do this,

1. Add the following two values to the ufs_desc_max_size value
- QUERY_DESC_DEVICE_MAX_SIZE_VENDOR_SS_MX
- QUERY_DESC_GEOMETRY_MAX_SIZE_VENDOR_SS_MX 


2. Modify the check_read_desc_size() function to check the above two added values together.


The changes are minimal and should still work if you follow the JEDEC specification
.