### PR TITLE
ufs_hmr: drop always-true check on 'opt->path'

### DIFF
--- a/ufs_hmr.c
+++ b/ufs_hmr.c
@@ -1100,7 +1100,7 @@ int do_hmr(struct tool_options *opt)
 	__u32 refresh_totcount;
 	enum hmr_stage_skip stage_passer = 0;
 
-	if (!opt || !opt->path)
+	if (!opt)
 		return -EHMR_INVAL;
 
 	/* Open dev in subject */


### PR DESCRIPTION
When building ufs-utils under Buildroot using GCC 13, the following warning is reported:

  ufs_hmr.c: In function ‘do_hmr’:
  ufs_hmr.c:1103:21: warning: the comparison will always evaluate as ‘true’ \
    for the address of ‘path’ will never be NULL [-Waddress]
    1103 |         if (!opt || !opt->path)
         |                     ^
  options.h:58:14: note: ‘path’ declared here
    58   |         char path[PATH_MAX];
         |              ^~~~

The 'path' field is a fixed-size array, not a pointer, so its address is always non-NULL.
Remove the invalid null check to silence the warning.