### PR TITLE
ufs_cmds: fix full_path buffer size in find_bsg_device

### DIFF
--- a/ufs_cmds.c
+++ b/ufs_cmds.c
@@ -1520,7 +1520,7 @@ static int find_bsg_device(char* path, int *counter) {
 			if ((strcmp(files->d_name, ".") != 0) &&
 			    (strcmp(files->d_name, "..") != 0)) {
 				char *full_path = (char *)malloc(strlen(path) +
-						   strlen(files->d_name) + 1);
+						   strlen(files->d_name) + 2);
 				sprintf(full_path, "%s/%s",
 					path, files->d_name);
 				rc = find_bsg_device(full_path, counter);


### PR DESCRIPTION
The full_path buffer consists of: path + '/' + files->d_name + '\0'
So the buffer size should be: strlen(path) + strlen(files->d_name) + 2

Fix crash when running 32-bit binary on 64-bit system: $ ufs-utils list_bsg
malloc(): invalid next size (unsorted)
Aborted (core dumped)

Fix #58