### PR TITLE
Prevent a memory overflow in verify_output_data

### DIFF
--- a/options.c
+++ b/options.c
@@ -882,7 +882,7 @@ static int verify_output_data(struct tool_options *options)
 		goto out;
 	}
 
-	len = strlen(optarg);
+	len = strlen(optarg) + 1;
 	if (len >= PATH_MAX) {
 		print_error("Output path is too long");
 		goto out;


### PR DESCRIPTION
Make sure the trailing `\0` is accounted for when allocating memory for a path.

Suggested-by: treapking@chromium.org